### PR TITLE
Use bytesNoCopy:length:encoding:freeWhenDone:

### DIFF
--- a/lockbox-ios/Action/FxAAction.swift
+++ b/lockbox-ios/Action/FxAAction.swift
@@ -140,9 +140,8 @@ extension FxAActionHandler {
     }
 
     private func deriveScopedKeyFromJWE(_ jwe: String) throws -> String {
-        let jweString = self.keyManager.decryptJWE(jwe)
-
-        guard let jsonValue = try JSONSerialization.jsonObject(with: jweString.data(using: .utf8)!) as? [String: Any],
+        guard let jweString = self.keyManager.decryptJWE(jwe),
+              let jsonValue = try JSONSerialization.jsonObject(with: jweString.data(using: .utf8)!) as? [String: Any],
               let jweJSON = jsonValue[scope] as? [String: Any] else {
             throw FxAError.UnexpectedDataFormat
         }

--- a/lockbox-ios/Common/Helpers/KeyManager.swift
+++ b/lockbox-ios/Common/Helpers/KeyManager.swift
@@ -18,15 +18,17 @@ class KeyManager {
         return String(cString: jsonValue!)
     }
 
-    func decryptJWE(_ jwe: String) -> String {
+    func decryptJWE(_ jwe: String) -> String? {
         let count = jwe.data(using: .utf8)!.count as size_t
         let contentLen = UnsafeMutablePointer<size_t>.allocate(capacity: count)
         let err = UnsafeMutablePointer<cjose_err>.allocate(capacity: count)
 
         let cJoseJWE = cjose_jwe_import(jwe, count, nil)
-        let decryptedPayload = cjose_jwe_decrypt(cJoseJWE, self.jwk, contentLen, err)
+        guard let decryptedPayload = cjose_jwe_decrypt(cJoseJWE, self.jwk, contentLen, err) else {
+            return nil
+        }
 
-        return String(cString: decryptedPayload!)
+        return String(bytesNoCopy: decryptedPayload, length: contentLen.pointee, encoding: .utf8, freeWhenDone: true)
     }
 
     func random32() -> Data? {


### PR DESCRIPTION
import non-null-terminated cstrings safely

resolves #120 