### PR TITLE
Add metrics plan; Define event methods and objects

### DIFF
--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -1,0 +1,133 @@
+# Lockbox for iOS Metrics Plan
+
+_Last Updated: March 14, 2018_
+
+<!-- TOC depthFrom:2 depthTo:6 withLinks:1 updateOnSave:1 orderedList:0 -->
+
+- [Analysis](#analysis)
+- [Collection](#collection)
+- [List of Proposed Events](#list-of-proposed-events)
+- [References](#references)
+
+<!-- /TOC -->
+
+This is the metrics collection plan for the Lockbox iOS app. It documents all events that are planned to be collected through telemetry. It will be updated periodically to reflect all new and planned data collection.
+
+## Analysis
+
+Data collection is done solely for the purpose of product development, improvement and maintenance.
+
+More here TBD
+
+## Collection
+
+Data will be collected using this library:
+
+https://github.com/mozilla-mobile/telemetry-ios/
+
+We plan to submit two ping types.
+
+First is the "core ping", which contains information about the iOS version, architecture, etc of the device lockbox has been installed on:
+
+https://firefox-source-docs.mozilla.org/toolkit/components/telemetry/telemetry/data/core-ping.html
+
+The second is the "focus event ping" which allows us to record event telemetry:
+
+https://github.com/mozilla-mobile/focus-ios/wiki/Event-Tracking-with-Mozilla%27s-Telemetry-Service
+
+The ping types are defined in `lockbox-ios/Common/AppDelegate.swift`. Scheduling of ping transmission is done in the same file.
+
+Every event must contain `category`, `method` and `object` fields, and may optionally contain `value` and `extra` fields as well. Possible values for the former three fields are defined in `lockbox-ios/TelemetryIntegration.swift`
+
+For all events, the `extra` field should contain the user's fxa uid, except for those that are recorded before the user authenticates with FxA.
+
+Events related to specific items should also have an item id in the extra field where possible.
+
+Here's an example of (something like) the swift code needed to record the event that fires when an item in the entry list is tapped:
+
+```swift
+Telemetry.default.recordEvent(
+	category: TelemetryEventCategory.action,
+	method: TelemetryEventMethod.tap,
+	object: TelemetryEventObject.entryList,
+	value: nil,
+	extras: ["fxauid" : uid, "itemid" : itemid]
+)
+```
+
+Finally, the `appName` metadata sent with each ping should always be 'Lockbox'.
+
+See here for more information on event schemas:
+
+https://firefox-source-docs.mozilla.org/toolkit/components/telemetry/telemetry/collection/events.html#public-js-api
+
+## List of Proposed Events
+
+1. When the user starts up the app:
+	* `category`: action
+	* `method`: startup
+	* `object`: app
+	* `value`: nil
+	* `extras`: ["fxauid" : uid or nil]
+		* Note: This might be able to replace the event that currently fires in `AppDelegate.swift`
+
+2. When a user taps the fxa signin button:
+	* `category`: action
+	* `method`: tap
+	* `object`: fxaSigninButton
+	* `value`: nil
+	* `extras`: nil
+
+3. Whether a user successfully authorizes with FxA:
+	* `category`: action
+	* `method`: signin
+	* `object`: app
+	* `value`: `true` or `false`
+	* `extras`: ["fxauid" : uid or nil, "error" : nil or string]
+		* Note: If there is an authentication error, let's put it in the extra field here, if possible.
+
+4. When a user taps an item in the entry list:
+	* `category`: action
+	* `method`: tap
+	* `object`: entryList
+	* `value`: nil
+	* `extras`: ["fxauid" : uid, "itemid" : itemid]
+
+5. When a user taps one of the buttons that are shown in the menu displayed after selecting an entry:
+	* `category`: action
+	* `method`: tap
+	* `object`: copyUsernameButton, copyPasswordButton, viewPasswordButton, viewItemButton, entryCancelButton
+	* `value`: nil
+	* `extras`: ["fxauid" : uid, "itemid" : itemid]
+
+6. When a user taps one of the buttons available after entering the entry view:
+	* `category`: action
+	* `method`: tap
+	* `object`: entryCopyUsernameButton, entryCopyPasswordButton, viewPasswordButton, entryShowPasswordButton
+	* `value`: nil
+	* `extras`: ["fxauid" : uid, "itemid" : itemid]
+		* Note: I might be OK with firing the same events as (4) here, if there is extra plumbing required to differentiate actions that happen in the overlay menu vs those that happen in the item view. However, it would be nice to know which of the two options users find most convenient, and to what extent.
+
+7. When a user taps the settings button:
+	* `category`: action
+	* `method`: tap
+	* `object`: settingsButton
+	* `value`: nil
+	* `extras`: ["fxauid" : uid]
+
+8. When a user taps the FAQ button:
+	* `category`: action
+	* `method`: tap
+	* `object`: faqButton
+	* `value`: nil
+	* `extras`: ["fxauid" : uid]
+
+## References
+
+[Library used to collect and send telemetry on iOS](https://github.com/mozilla-mobile/telemetry-ios/)
+
+[Description of the "Core" ping](https://firefox-source-docs.mozilla.org/toolkit/components/telemetry/telemetry/data/core-ping.html)
+
+[Description of the "Focus Event" Ping](https://github.com/mozilla-mobile/focus-ios/wiki/Event-Tracking-with-Mozilla%27s-Telemetry-Service)
+
+[Description of Event Schemas in General](https://firefox-source-docs.mozilla.org/toolkit/components/telemetry/telemetry/collection/events.html#public-js-api)

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -63,13 +63,12 @@ https://firefox-source-docs.mozilla.org/toolkit/components/telemetry/telemetry/c
 
 ## List of Proposed Events
 
-1. When the user starts up the app:
+1. When the app starts up:
 	* `category`: action
 	* `method`: startup
 	* `object`: app
 	* `value`: nil
-	* `extras`: ["fxauid" : uid or nil]
-		* Note: This might be able to replace the event that currently fires in `AppDelegate.swift`
+	* `extras`: nil
 
 2. When a user taps the fxa signin button:
 	* `category`: action
@@ -78,7 +77,7 @@ https://firefox-source-docs.mozilla.org/toolkit/components/telemetry/telemetry/c
 	* `value`: nil
 	* `extras`: nil
 
-3. Whether a user successfully authorizes with FxA:
+2. Whether a user successfully authorizes with FxA:
 	* `category`: action
 	* `method`: signin
 	* `object`: app
@@ -86,39 +85,38 @@ https://firefox-source-docs.mozilla.org/toolkit/components/telemetry/telemetry/c
 	* `extras`: ["fxauid" : uid or nil, "error" : nil or string]
 		* Note: If there is an authentication error, let's put it in the extra field here, if possible.
 
-4. When a user taps an item in the entry list:
+3. When a user taps an item in the entry list:
 	* `category`: action
 	* `method`: tap
 	* `object`: entryList
 	* `value`: nil
 	* `extras`: ["fxauid" : uid, "itemid" : itemid]
 
-5. When a user taps one of the buttons that are shown in the menu displayed after selecting an entry:
-	* `category`: action
-	* `method`: tap
-	* `object`: copyUsernameButton, copyPasswordButton, viewPasswordButton, viewItemButton, entryCancelButton
-	* `value`: nil
-	* `extras`: ["fxauid" : uid, "itemid" : itemid]
-
-6. When a user taps one of the buttons available after entering the entry view:
+4. When a user taps one of the buttons available after entering the entry view:
 	* `category`: action
 	* `method`: tap
 	* `object`: entryCopyUsernameButton, entryCopyPasswordButton, viewPasswordButton, entryShowPasswordButton
 	* `value`: nil
 	* `extras`: ["fxauid" : uid, "itemid" : itemid]
-		* Note: I might be OK with firing the same events as (4) here, if there is extra plumbing required to differentiate actions that happen in the overlay menu vs those that happen in the item view. However, it would be nice to know which of the two options users find most convenient, and to what extent.
 
-7. When a user taps the settings button:
+5. When a user taps the settings button:
 	* `category`: action
 	* `method`: tap
 	* `object`: settingsButton
 	* `value`: nil
 	* `extras`: ["fxauid" : uid]
 
-8. When a user taps the FAQ button:
+6. When a user taps the FAQ button:
 	* `category`: action
 	* `method`: tap
 	* `object`: faqButton
+	* `value`: nil
+	* `extras`: ["fxauid" : uid]
+
+7. When the app enters the background or foreground:
+	* `category`: action
+	* `method`: background, foreground
+	* `object`: app
 	* `value`: nil
 	* `extras`: ["fxauid" : uid]
 

--- a/lockbox-ios/Common/AppDelegate.swift
+++ b/lockbox-ios/Common/AppDelegate.swift
@@ -74,7 +74,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         Telemetry.default.recordSessionStart()
         Telemetry.default.recordEvent(
                 category: TelemetryEventCategory.action,
-                method: TelemetryEventMethod.foreground,
+                method: TelemetryEventMethod.startup,
                 object: TelemetryEventObject.app
         )
     }

--- a/lockbox-ios/TelemetryIntegration.swift
+++ b/lockbox-ios/TelemetryIntegration.swift
@@ -9,9 +9,11 @@ class TelemetryEventCategory {
 }
 
 class TelemetryEventMethod {
+    public static let startup = "startup"
     public static let background = "background"
     public static let foreground = "foreground"
-    public static let click = "click"
+    public static let tap = "tap"
+    public static let signin = "signin"
 }
 
 class TelemetryEventObject {
@@ -19,4 +21,17 @@ class TelemetryEventObject {
     public static let initStoreButton = "init_store_button"
     public static let unlockStoreButton = "unlock_store_button"
     public static let listStoreContentsButton = "list_store_contents_button"
+    public static let entryList = "entry_list"
+    public static let settingsButton = "settings_button"
+    public static let feedbackButton = "feedback_button"
+    public static let faqButton = "faq_button"
+    public static let copyUsernameButton = "copy_username_button"
+    public static let copyPasswordButton = "copy_password_button"
+    public static let viewPasswordButton = "view_password_button"
+    public static let viewEntryButton = "view_entry_button"
+    public static let entryCancelButton = "entry_cancel_button"
+    public static let entryCopyUsernameButton = "entry_copy_username_button"
+    public static let entryCopyPasswordButton = "entry_copy_password_button"
+    public static let entryShowPasswordButton = "entry_view_password_button"
+
 }

--- a/lockbox-ios/TelemetryIntegration.swift
+++ b/lockbox-ios/TelemetryIntegration.swift
@@ -11,7 +11,7 @@ class TelemetryEventCategory {
 class TelemetryEventMethod {
     public static let tap = "tap"
     public static let signin = "signin"
-    public static let signin = "startup"
+    public static let startup = "startup"
     public static let foreground = "foreground"
     public static let background = "background"
 }

--- a/lockbox-ios/TelemetryIntegration.swift
+++ b/lockbox-ios/TelemetryIntegration.swift
@@ -9,18 +9,15 @@ class TelemetryEventCategory {
 }
 
 class TelemetryEventMethod {
-    public static let startup = "startup"
-    public static let background = "background"
-    public static let foreground = "foreground"
     public static let tap = "tap"
     public static let signin = "signin"
+    public static let signin = "startup"
+    public static let foreground = "foreground"
+    public static let background = "background"
 }
 
 class TelemetryEventObject {
     public static let app = "app"
-    public static let initStoreButton = "init_store_button"
-    public static let unlockStoreButton = "unlock_store_button"
-    public static let listStoreContentsButton = "list_store_contents_button"
     public static let entryList = "entry_list"
     public static let settingsButton = "settings_button"
     public static let feedbackButton = "feedback_button"


### PR DESCRIPTION
Resolves #130 

OK, here is a first pass at a list of events we'd like to record given the current functionality (as I understand it anyway). In metrics.md I add a few notes of things I'm unsure about; here's a brief tl;dr:

1. We need to have the fxa uid present in the `extras` field of every event where possible (i.e. after authentication) - we currently do this for the extension but if its more difficult here, let me know.

2. I'm unsure of how hard it is to capture errors in a succinct way if fxa authentication fails for some reason. It would be nice to have a short, interpretable error code or message that is added to the extras field on the events that tracks authentication failure / success. 

3. I went ahead and defined the required event methods and objects in `TelemetryIntegration.swift` . If I fouled this up let me know.

Let me know how else I can help or if something is not clear or stupid. I think I get the basics of the mechanics here, so willing to try my hand at placing some of the events in myself, if needed.

Thanks!