### PR TITLE
Load FxA sign in mode not default sign up mode

### DIFF
--- a/lockbox-ios/Action/FxAAction.swift
+++ b/lockbox-ios/Action/FxAAction.swift
@@ -65,6 +65,7 @@ class FxAActionHandler: ActionHandler {
             URLQueryItem(name: "client_id", value: Constant.fxa.clientID),
             URLQueryItem(name: "redirect_uri", value: Constant.app.redirectURI),
             URLQueryItem(name: "scope", value: "profile openid \(self?.scope ?? "")"),
+            URLQueryItem(name: "action", value: "signin"),
             URLQueryItem(name: "keys_jwk", value: self?.jwkKey ?? ""),
             URLQueryItem(name: "state", value: self?.state),
             URLQueryItem(name: "code_challenge", value: self?.codeChallenge),

--- a/lockbox-iosTests/FxAActionSpec.swift
+++ b/lockbox-iosTests/FxAActionSpec.swift
@@ -113,6 +113,7 @@ class FxAActionSpec: QuickSpec {
                             URLQueryItem(name: "client_id", value: Constant.fxa.clientID),
                             URLQueryItem(name: "redirect_uri", value: Constant.app.redirectURI),
                             URLQueryItem(name: "scope", value: "profile openid \(self.subject.scope)"),
+                            URLQueryItem(name: "action", value: "signin"),
                             URLQueryItem(name: "keys_jwk", value: self.subject.jwkKey),
                             URLQueryItem(name: "state", value: self.subject.state),
                             URLQueryItem(name: "code_challenge", value: self.subject.codeChallenge),


### PR DESCRIPTION
This assumes the user already has a Firefox Account and takes them straight to sign in (versus tapping out of registration mode).

<img width="252" alt="screen shot 2018-03-28 at 10 04 58 am" src="https://user-images.githubusercontent.com/49511/38041633-838b9d90-326f-11e8-9224-a3a18067676c.png">
