### PR TITLE
Point CODEOWNERS to a team, not an individual

### DIFF
--- a/docs/CODEOWNERS
+++ b/docs/CODEOWNERS
@@ -1,8 +1,5 @@
 # lockbox-ios code owners
 # https://help.github.com/articles/about-codeowners/
 
-# docs are shepherded by @devinreams
-/docs/    @sashei @devinreams
-
-# otherwise, everything is to be reviewed by @sashei
-* @sashei
+# everything is to be reviewed by the mobile team (for now..)
+* @mozilla-lockbox/mobile-engineering


### PR DESCRIPTION
This way any new PR requests a review from the "Mobile Engineering team" which is currently comprised of @sashei and @jhugman: https://github.com/orgs/mozilla-lockbox/teams/mobile-engineering


![screen shot 2018-04-09 at 12 21 43 pm](https://user-images.githubusercontent.com/49511/38515148-a262f9cc-3bf0-11e8-8fec-489eada599af.png)
(look at this pull request as an example)

Whoever reviews first then is shown as reviewing "on behalf of" the team. In other words, it doesn't explicitly request a review from all people, ultimately just one representative of the team is needed.

