### PR TITLE
Restore xcode code coverage reports for codecov

### DIFF
--- a/buddybuild_postbuild.sh
+++ b/buddybuild_postbuild.sh
@@ -1,2 +1,2 @@
 #!/usr/bin/env bash
-bash <(curl -s https://codecov.io/bash) -t $CODECOV_TOKEN
+bash <(curl -s https://codecov.io/bash) -J Lockbox -t $CODECOV_TOKEN


### PR DESCRIPTION
Fixes #219 

Watch my flailing attempts to get xcode coverage reports restored and sent to codecov.