### PR TITLE
[WIP] Remove unneeded binary architectures

### DIFF
--- a/scripts/update-dependencies
+++ b/scripts/update-dependencies
@@ -19,7 +19,7 @@ export MINVERSION=9.0
 # download & cross-compile openssl (most of the heavy lifting done by iconfigure-openssl)
 OPENSSLDIR="openssl"
 cd "${OPENSSLDIR}"
-source "iconfigure-openssl" --archs="x86_64 i386 arm64 armv7s armv7"
+source "iconfigure-openssl" --archs="arm64 armv7s armv7"
 cd ..
 
 # download & cross-compile jansson

--- a/scripts/update-dependencies
+++ b/scripts/update-dependencies
@@ -10,7 +10,7 @@ BINARY_DIR="../lockbox-ios/binaries"
 
 JANSSON_VERSION=2.10
 JANSSON_SRC="http://www.digip.org/jansson/releases/jansson-${JANSSON_VERSION}.tar.gz"
-CJOSE_VERSION=0.6.0
+CJOSE_VERSION=master
 CJOSE_SRC="https://github.com/cisco/cjose/archive/${CJOSE_VERSION}.tar.gz"
 SCRIPT_DIR="$(pwd)"
 ARCHS="armv7 armv7s arm64"

--- a/scripts/update-dependencies
+++ b/scripts/update-dependencies
@@ -13,13 +13,14 @@ JANSSON_SRC="http://www.digip.org/jansson/releases/jansson-${JANSSON_VERSION}.ta
 CJOSE_VERSION=0.6.0
 CJOSE_SRC="https://github.com/cisco/cjose/archive/${CJOSE_VERSION}.tar.gz"
 SCRIPT_DIR="$(pwd)"
+ARCHS="armv7 armv7s arm64"
 
 export MINVERSION=9.0
 
 # download & cross-compile openssl (most of the heavy lifting done by iconfigure-openssl)
 OPENSSLDIR="openssl"
 cd "${OPENSSLDIR}"
-source "iconfigure-openssl" --archs="arm64 armv7s armv7"
+source "iconfigure-openssl" --archs="${ARCHS}"
 cd ..
 
 # download & cross-compile jansson
@@ -30,6 +31,7 @@ tar zxf "${JANSSON_ARCHIVE_FILE}"
 cp iconfigure "${JANSSON_FILE}"
 cp autoframework "${JANSSON_FILE}"
 
+export ARCHS=${ARCHS}
 cd "${JANSSON_FILE}"
 source "autoframework" Jansson libjansson.a
 


### PR DESCRIPTION
References #211 

@sashei I thought this was a good place to start, just remove and rebuild with only the needed architectures.

But, I'm unable to complete `./update-dependencies` before or after this change for some reason. Are you? My error starts around here:

```
/bin/sh ../libtool  --tag=CC   --mode=compile /Applications/Xcode.app/Contents/Developer/usr/bin/gcc -DPACKAGE_NAME=\"cjose\" -DPACKAGE_TARNAME=\"cjose\" -DPACKAGE_VERSION=\"0.6.0\" -DPACKAGE_STRING=\"cjose\ 0.6.0\" -DPACKAGE_BUGREPORT=\"\" -DPACKAGE_URL=\"\" -DPACKAGE=\"cjose\" -DVERSION=\"0.6.0\" -DSTDC_HEADERS=1 -DHAVE_SYS_TYPES_H=1 -DHAVE_SYS_STAT_H=1 -DHAVE_STDLIB_H=1 -DHAVE_STRING_H=1 -DHAVE_MEMORY_H=1 -DHAVE_STRINGS_H=1 -DHAVE_INTTYPES_H=1 -DHAVE_STDINT_H=1 -DHAVE_UNISTD_H=1 -DHAVE_DLFCN_H=1 -DLT_OBJDIR=\".libs/\" -DHAVE_LIBCRYPTO=1 -DHAVE_LIBJANSSON=1 -I.  -I/include -arch arm64 -isysroot /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS11.3.sdk -I/Users/dreams/src/lockbox-ios/scripts/cjose-0.6.0/Static/arm64/include -miphoneos-version-min=9.0 -I/Users/dreams/src/lockbox-ios/scripts/openssl//include/ -I/Users/dreams/src/lockbox-ios/scripts/jansson-2.10/Frameworks//include/ -std=gnu99 --pedantic -Wall -Werror -g -O2 -I../include -arch arm64 -isysroot /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS11.3.sdk -I/Users/dreams/src/lockbox-ios/scripts/cjose-0.6.0/Static/arm64/include -miphoneos-version-min=9.0 -I/Users/dreams/src/lockbox-ios/scripts/openssl//include/ -I/Users/dreams/src/lockbox-ios/scripts/jansson-2.10/Frameworks//include/ -MT libcjose_la-version.lo -MD -MP -MF .deps/libcjose_la-version.Tpo -c -o libcjose_la-version.lo `test -f 'version.c' || echo './'`version.c
libtool: compile:  /Applications/Xcode.app/Contents/Developer/usr/bin/gcc -DPACKAGE_NAME=\"cjose\" -DPACKAGE_TARNAME=\"cjose\" -DPACKAGE_VERSION=\"0.6.0\" "-DPACKAGE_STRING=\"cjose 0.6.0\"" -DPACKAGE_BUGREPORT=\"\" -DPACKAGE_URL=\"\" -DPACKAGE=\"cjose\" -DVERSION=\"0.6.0\" -DSTDC_HEADERS=1 -DHAVE_SYS_TYPES_H=1 -DHAVE_SYS_STAT_H=1 -DHAVE_STDLIB_H=1 -DHAVE_STRING_H=1 -DHAVE_MEMORY_H=1 -DHAVE_STRINGS_H=1 -DHAVE_INTTYPES_H=1 -DHAVE_STDINT_H=1 -DHAVE_UNISTD_H=1 -DHAVE_DLFCN_H=1 -DLT_OBJDIR=\".libs/\" -DHAVE_LIBCRYPTO=1 -DHAVE_LIBJANSSON=1 -I. -I/include -arch arm64 -isysroot /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS11.3.sdk -I/Users/dreams/src/lockbox-ios/scripts/cjose-0.6.0/Static/arm64/include -miphoneos-version-min=9.0 -I/Users/dreams/src/lockbox-ios/scripts/openssl//include/ -I/Users/dreams/src/lockbox-ios/scripts/jansson-2.10/Frameworks//include/ -std=gnu99 --pedantic -Wall -Werror -g -O2 -I../include -arch arm64 -isysroot /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS11.3.sdk -I/Users/dreams/src/lockbox-ios/scripts/cjose-0.6.0/Static/arm64/include -miphoneos-version-min=9.0 -I/Users/dreams/src/lockbox-ios/scripts/openssl//include/ -I/Users/dreams/src/lockbox-ios/scripts/jansson-2.10/Frameworks//include/ -MT libcjose_la-version.lo -MD -MP -MF .deps/libcjose_la-version.Tpo -c version.c -o libcjose_la-version.o
mv -f .deps/libcjose_la-version.Tpo .deps/libcjose_la-version.Plo
/bin/sh ../libtool  --tag=CC   --mode=compile /Applications/Xcode.app/Contents/Developer/usr/bin/gcc -DPACKAGE_NAME=\"cjose\" -DPACKAGE_TARNAME=\"cjose\" -DPACKAGE_VERSION=\"0.6.0\" -DPACKAGE_STRING=\"cjose\ 0.6.0\" -DPACKAGE_BUGREPORT=\"\" -DPACKAGE_URL=\"\" -DPACKAGE=\"cjose\" -DVERSION=\"0.6.0\" -DSTDC_HEADERS=1 -DHAVE_SYS_TYPES_H=1 -DHAVE_SYS_STAT_H=1 -DHAVE_STDLIB_H=1 -DHAVE_STRING_H=1 -DHAVE_MEMORY_H=1 -DHAVE_STRINGS_H=1 -DHAVE_INTTYPES_H=1 -DHAVE_STDINT_H=1 -DHAVE_UNISTD_H=1 -DHAVE_DLFCN_H=1 -DLT_OBJDIR=\".libs/\" -DHAVE_LIBCRYPTO=1 -DHAVE_LIBJANSSON=1 -I.  -I/include -arch arm64 -isysroot /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS11.3.sdk -I/Users/dreams/src/lockbox-ios/scripts/cjose-0.6.0/Static/arm64/include -miphoneos-version-min=9.0 -I/Users/dreams/src/lockbox-ios/scripts/openssl//include/ -I/Users/dreams/src/lockbox-ios/scripts/jansson-2.10/Frameworks//include/ -std=gnu99 --pedantic -Wall -Werror -g -O2 -I../include -arch arm64 -isysroot /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS11.3.sdk -I/Users/dreams/src/lockbox-ios/scripts/cjose-0.6.0/Static/arm64/include -miphoneos-version-min=9.0 -I/Users/dreams/src/lockbox-ios/scripts/openssl//include/ -I/Users/dreams/src/lockbox-ios/scripts/jansson-2.10/Frameworks//include/ -MT libcjose_la-util.lo -MD -MP -MF .deps/libcjose_la-util.Tpo -c -o libcjose_la-util.lo `test -f 'util.c' || echo './'`util.c
libtool: compile:  /Applications/Xcode.app/Contents/Developer/usr/bin/gcc -DPACKAGE_NAME=\"cjose\" -DPACKAGE_TARNAME=\"cjose\" -DPACKAGE_VERSION=\"0.6.0\" "-DPACKAGE_STRING=\"cjose 0.6.0\"" -DPACKAGE_BUGREPORT=\"\" -DPACKAGE_URL=\"\" -DPACKAGE=\"cjose\" -DVERSION=\"0.6.0\" -DSTDC_HEADERS=1 -DHAVE_SYS_TYPES_H=1 -DHAVE_SYS_STAT_H=1 -DHAVE_STDLIB_H=1 -DHAVE_STRING_H=1 -DHAVE_MEMORY_H=1 -DHAVE_STRINGS_H=1 -DHAVE_INTTYPES_H=1 -DHAVE_STDINT_H=1 -DHAVE_UNISTD_H=1 -DHAVE_DLFCN_H=1 -DLT_OBJDIR=\".libs/\" -DHAVE_LIBCRYPTO=1 -DHAVE_LIBJANSSON=1 -I. -I/include -arch arm64 -isysroot /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS11.3.sdk -I/Users/dreams/src/lockbox-ios/scripts/cjose-0.6.0/Static/arm64/include -miphoneos-version-min=9.0 -I/Users/dreams/src/lockbox-ios/scripts/openssl//include/ -I/Users/dreams/src/lockbox-ios/scripts/jansson-2.10/Frameworks//include/ -std=gnu99 --pedantic -Wall -Werror -g -O2 -I../include -arch arm64 -isysroot /Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS11.3.sdk -I/Users/dreams/src/lockbox-ios/scripts/cjose-0.6.0/Static/arm64/include -miphoneos-version-min=9.0 -I/Users/dreams/src/lockbox-ios/scripts/openssl//include/ -I/Users/dreams/src/lockbox-ios/scripts/jansson-2.10/Frameworks//include/ -MT libcjose_la-util.lo -MD -MP -MF .deps/libcjose_la-util.Tpo -c util.c -o libcjose_la-util.o
util.c:53:6: error: macro expansion producing 'defined' has undefined behavior [-Werror,-Wexpansion-to-defined]
#if (CJOSE_OPENSSL_11X)
     ^
../include/cjose/util.h:27:69: note: expanded from macro 'CJOSE_OPENSSL_11X'
#define CJOSE_OPENSSL_11X OPENSSL_VERSION_NUMBER >= 0x10100005L && !defined(LIBRESSL_VERSION_NUMBER)
                                                                    ^
1 error generated.
make[1]: *** [libcjose_la-util.lo] Error 1
make: *** [all-recursive] Error 1
```