### PR TITLE
Set default button text to "Sign in.." instead of "Get Started"

### DIFF
--- a/lockbox-ios/Storyboard/Base.lproj/Welcome.storyboard
+++ b/lockbox-ios/Storyboard/Base.lproj/Welcome.storyboard
@@ -59,7 +59,7 @@
                                     <constraint firstAttribute="width" relation="greaterThanOrEqual" priority="750" constant="315" id="v9d-HV-Tyg"/>
                                 </constraints>
                                 <fontDescription key="fontDescription" type="system" pointSize="15"/>
-                                <state key="normal" title="Get Started">
+                                <state key="normal" title="Sign in with your Firefox Account">
                                     <color key="titleColor" red="0.059756595641374588" green="0.3597700297832489" blue="0.8745732307434082" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
                                 </state>
                             </button>

--- a/lockbox-ios/Storyboard/de.lproj/Welcome.strings
+++ b/lockbox-ios/Storyboard/de.lproj/Welcome.strings
@@ -2,8 +2,8 @@
 /* Class = "UILabel"; text = "Lockbox"; ObjectID = "Ctm-Z1-jcM"; */
 "Ctm-Z1-jcM.text" = "Lockbox";
 
-/* Class = "UIButton"; normalTitle = "Get Started"; ObjectID = "cuz-yd-F4J"; */
-"cuz-yd-F4J.normalTitle" = "Get Started";
+/* Class = "UIButton"; normalTitle = "Sign in with your Firefox Account"; ObjectID = "cuz-yd-F4J"; */
+"cuz-yd-F4J.normalTitle" = "Sign in with your Firefox Account";
 
 /* Class = "UILabel"; text = "your companion for accessing  saved Firefox logins"; ObjectID = "hwO-wS-oS4"; */
 "hwO-wS-oS4.text" = "your companion for accessing  saved Firefox logins";

--- a/lockbox-ios/Storyboard/en.lproj/Welcome.strings
+++ b/lockbox-ios/Storyboard/en.lproj/Welcome.strings
@@ -2,8 +2,8 @@
 /* Class = "UILabel"; text = "Lockbox"; ObjectID = "Ctm-Z1-jcM"; */
 "Ctm-Z1-jcM.text" = "Lockbox";
 
-/* Class = "UIButton"; normalTitle = "Get Started"; ObjectID = "cuz-yd-F4J"; */
-"cuz-yd-F4J.normalTitle" = "Get Started";
+/* Class = "UIButton"; normalTitle = "Sign in with your Firefox Account"; ObjectID = "cuz-yd-F4J"; */
+"cuz-yd-F4J.normalTitle" = "Sign in with your Firefox Account";
 
 /* Class = "UILabel"; text = "your companion for accessing  saved Firefox logins"; ObjectID = "hwO-wS-oS4"; */
 "hwO-wS-oS4.text" = "your companion for accessing  saved Firefox logins";

--- a/lockbox-ios/Storyboard/es.lproj/Welcome.strings
+++ b/lockbox-ios/Storyboard/es.lproj/Welcome.strings
@@ -10,4 +10,3 @@
 
 /* Class = "UILabel"; text = "In order for Lockbox to display saved logins, you need to enable sync on Firefox."; ObjectID = "xyY-bk-Xw8"; */
 "xyY-bk-Xw8.text" = "In order for Lockbox to display saved logins, you need to enable sync on Firefox.";
-


### PR DESCRIPTION
I accidentally changed this to "Get Started" but realize that's for first run, not signed in. "Sign In" is the best default and "Get Started" for first run/not signed in is arguably a nice-to-have and rarely encountered.

Related to #239

<img width="270" alt="screen shot 2018-04-12 at 2 18 02 pm" src="https://user-images.githubusercontent.com/49511/38701918-677168ee-3e5c-11e8-946d-e64f763d71b0.png">
