### PR TITLE
Expire the copy pasteboard after 60 seconds

### DIFF
--- a/lockbox-ios/Action/CopyAction.swift
+++ b/lockbox-ios/Action/CopyAction.swift
@@ -4,6 +4,7 @@
 
 import Foundation
 import UIKit
+import MobileCoreServices
 
 struct CopyAction: Action {
     let text: String
@@ -40,7 +41,8 @@ class CopyActionHandler: ActionHandler {
     }
 
     func invoke(_ action: CopyAction) {
-        self.pasteboard.string = action.text
+        self.pasteboard.setItems([[kUTTypeUTF8PlainText as String: action.text]],
+                                options: [UIPasteboardOption.expirationDate: Date().addingTimeInterval(60)])
         self.dispatcher.dispatch(action: CopyConfirmationDisplayAction(fieldName: action.fieldName))
     }
 }

--- a/lockbox-ios/Action/CopyAction.swift
+++ b/lockbox-ios/Action/CopyAction.swift
@@ -41,8 +41,10 @@ class CopyActionHandler: ActionHandler {
     }
 
     func invoke(_ action: CopyAction) {
+        let expireDate = Date().addingTimeInterval(TimeInterval(Constant.number.copyExpireTimeSecs))
+
         self.pasteboard.setItems([[kUTTypeUTF8PlainText as String: action.text]],
-                                options: [UIPasteboardOption.expirationDate: Date().addingTimeInterval(60)])
+                                 options: [UIPasteboardOption.expirationDate: expireDate])
         self.dispatcher.dispatch(action: CopyConfirmationDisplayAction(fieldName: action.fieldName))
     }
 }

--- a/lockbox-ios/Action/CopyAction.swift
+++ b/lockbox-ios/Action/CopyAction.swift
@@ -4,7 +4,6 @@
 
 import Foundation
 import UIKit
-import MobileCoreServices
 
 struct CopyAction: Action {
     let text: String
@@ -43,7 +42,7 @@ class CopyActionHandler: ActionHandler {
     func invoke(_ action: CopyAction) {
         let expireDate = Date().addingTimeInterval(TimeInterval(Constant.number.copyExpireTimeSecs))
 
-        self.pasteboard.setItems([[kUTTypeUTF8PlainText as String: action.text]],
+        self.pasteboard.setItems([[UIPasteboardTypeAutomatic: action.text]],
                                  options: [UIPasteboardOption.expirationDate: expireDate])
         self.dispatcher.dispatch(action: CopyConfirmationDisplayAction(fieldName: action.fieldName))
     }

--- a/lockbox-ios/Common/Resources/Constants.swift
+++ b/lockbox-ios/Common/Resources/Constants.swift
@@ -80,6 +80,7 @@ struct Constant {
         static let displayStatusAlertYPercentage: CGFloat = 0.4
         static let fxaButtonTopSpaceFirstLogin: CGFloat = 88.0
         static let fxaButtonTopSpaceUnlock: CGFloat = 40.0
+        static let copyExpireTimeSecs = 60
     }
 
     struct setting {

--- a/lockbox-iosTests/CopyActionSpec.swift
+++ b/lockbox-iosTests/CopyActionSpec.swift
@@ -19,16 +19,14 @@ class CopyActionSpec: QuickSpec {
     }
 
     class FakePasteboard: UIPasteboard {
-        var newString: String?
+        var passedItems: [[String: Any]]?
+        var options: [UIPasteboardOption: Any]?
 
-        override var string: String? {
-            get {
-                return super.string
-            }
-            set {
-                self.newString = newValue
-            }
+        override func setItems(_ items: [[String: Any]], options: [UIPasteboardOption: Any]) {
+            self.passedItems = items
+            self.options = options
         }
+
     }
 
     private var dispatcher: FakeDispatcher!
@@ -56,8 +54,11 @@ class CopyActionSpec: QuickSpec {
                     self.subject.invoke(action)
                 }
 
-                it("copies the text to the pasteboard") {
-                    expect(self.pasteboard.newString).to(equal(text))
+                it("add the item to the pasteboard with item and timeout option") {
+                    let expireDate = Date().addingTimeInterval(TimeInterval(Constant.number.copyExpireTimeSecs))
+
+                    expect(self.pasteboard.passedItems![0][UIPasteboardTypeAutomatic] as? String).to(equal(text))
+                    expect(self.pasteboard.options![UIPasteboardOption.expirationDate] as! NSDate).to(beCloseTo(expireDate, within: 0.1))
                 }
 
                 it("dispatches the copied action") {

--- a/lockbox-iosTests/CopyActionSpec.swift
+++ b/lockbox-iosTests/CopyActionSpec.swift
@@ -26,7 +26,6 @@ class CopyActionSpec: QuickSpec {
             self.passedItems = items
             self.options = options
         }
-
     }
 
     private var dispatcher: FakeDispatcher!


### PR DESCRIPTION
Resolves #232 

This was even easier than I thought so went ahead to attempt doing it myself.

Two things:

1. I got stuck making getting a type set in "setItems" but after crawling around Stack Overflow I think this is right... maybe there's a simpler/better/correct-er way?

2. I know some sort of test/spec is needed but it was not obvious to me how I should wait and make sure the pasteboard was emptied. That part may be harder than the change itself...?

---

- [x] need to confirm "60 seconds" is the right length we want
- [x] need to fix / write tests
