### PR TITLE
Don't let empty state scroll

### DIFF
--- a/lockbox-ios/View/ItemListView.swift
+++ b/lockbox-ios/View/ItemListView.swift
@@ -80,6 +80,7 @@ extension ItemListView: ItemListViewProtocol {
     func displayEmptyStateMessaging() {
         if let emptyStateView = Bundle.main.loadNibNamed("EmptyList", owner: self)?[0] as? UIView {
             self.tableView.backgroundView?.addSubview(emptyStateView)
+            self.tableView.isScrollEnabled = false
         }
 
         if let button = self.navigationItem.leftBarButtonItem?.customView as? UIButton {
@@ -90,6 +91,7 @@ extension ItemListView: ItemListViewProtocol {
 
     func hideEmptyStateMessaging() {
         self.tableView.backgroundView?.subviews.forEach({ $0.removeFromSuperview() })
+        self.tableView.isScrollEnabled = true
 
         if let button = self.navigationItem.leftBarButtonItem?.customView as? UIButton {
             button.isHidden = false

--- a/lockbox-iosTests/ItemListViewSpec.swift
+++ b/lockbox-iosTests/ItemListViewSpec.swift
@@ -150,6 +150,10 @@ class ItemListViewSpec: QuickSpec {
                 it("hides the left bar button item") {
                     expect(self.subject.navigationItem.leftBarButtonItem!.customView!.isHidden).to(beTrue())
                 }
+
+                it("disables scrolling") {
+                    expect(self.subject.tableView.isScrollEnabled).to(beFalse())
+                }
             }
 
             describe("hideEmptyStateMessaging") {
@@ -164,6 +168,10 @@ class ItemListViewSpec: QuickSpec {
 
                 it("shows the left bar button item") {
                     expect(self.subject.navigationItem.leftBarButtonItem!.customView!.isHidden).to(beFalse())
+                }
+
+                it("enables scrolling") {
+                    expect(self.subject.tableView.isScrollEnabled).to(beTrue())
                 }
             }
 


### PR DESCRIPTION
Right now the empty state allows you to pull down revealing a row header. This PR removes that.