### PR TITLE
Alphabetically sort "open in browser" settings

### DIFF
--- a/lockbox-ios/Presenter/PreferredBrowserSettingPresenter.swift
+++ b/lockbox-ios/Presenter/PreferredBrowserSettingPresenter.swift
@@ -19,12 +19,12 @@ class PreferredBrowserSettingPresenter {
     private var disposeBag = DisposeBag()
 
     lazy var initialSettings = [
-        CheckmarkSettingCellConfiguration(text: Constant.string.settingsBrowserChrome,
-                                          valueWhenChecked: PreferredBrowserSetting.Chrome),
         CheckmarkSettingCellConfiguration(text: Constant.string.settingsBrowserFirefox,
                                           valueWhenChecked: PreferredBrowserSetting.Firefox),
         CheckmarkSettingCellConfiguration(text: Constant.string.settingsBrowserFocus,
                                           valueWhenChecked: PreferredBrowserSetting.Focus),
+        CheckmarkSettingCellConfiguration(text: Constant.string.settingsBrowserChrome,
+                                          valueWhenChecked: PreferredBrowserSetting.Chrome),
         CheckmarkSettingCellConfiguration(text: Constant.string.settingsBrowserSafari,
                                           valueWhenChecked: PreferredBrowserSetting.Safari)
     ]


### PR DESCRIPTION
After we asked to set these to full names during PR review, they accidentally went out of alphabetical order.

Now they're back in alphabetical order:

![screen shot 2018-04-19 at 3 19 44 pm](https://user-images.githubusercontent.com/49511/39019026-2a2fac00-43e5-11e8-8b3d-49a90be0bbd0.png)

🎩 noted by @jhugman during review today