### PR TITLE
Set FxA redirect_uri back to expected

### DIFF
--- a/lockbox-ios/Common/Resources/Constants.swift
+++ b/lockbox-ios/Common/Resources/Constants.swift
@@ -8,7 +8,7 @@ import UIKit
 
 struct Constant {
     struct app {
-        static let redirectURI = "https://lockbox.firefox.com/fxa/ios-redirect.html"
+        static let redirectURI = "https://mozilla-lockbox.github.io/fxa/ios-redirect.html"
         static let faqURL = "https://lockbox.firefox.com/faq.html"
         static let provideFeedbackURL = "https://qsurvey.mozilla.com/s3/Lockbox-Input"
     }

--- a/lockbox-iosTests/FxAPresenterSpec.swift
+++ b/lockbox-iosTests/FxAPresenterSpec.swift
@@ -175,7 +175,7 @@ class FxAPresenterSpec: QuickSpec {
 
                     beforeEach {
                         urlComponents.scheme = "https"
-                        urlComponents.host = "lockbox.firefox.com"
+                        urlComponents.host = "mozilla-lockbox.github.io"
                         urlComponents.path = "/fxa/ios-redirect.html"
 
                         let request = URLRequest(url: urlComponents.url!)


### PR DESCRIPTION
Follow up to #322 

I'm now getting a "Bad Request: Incorrect redirect_uri" error on the FxA sign in flow. I _must_ have tested signing out and back in when working on that branch but ... perhaps not. 😔 
