### PR TITLE
Set search/filter to a darker placeholder text color

### DIFF
--- a/lockbox-ios/Storyboard/Base.lproj/ItemList.storyboard
+++ b/lockbox-ios/Storyboard/Base.lproj/ItemList.storyboard
@@ -45,6 +45,11 @@
                                                     <nil key="textColor"/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="15"/>
                                                     <textInputTraits key="textInputTraits" autocorrectionType="no"/>
+                                                    <userDefinedRuntimeAttributes>
+                                                        <userDefinedRuntimeAttribute type="color" keyPath="_placeholderLabel.textColor">
+                                                            <color key="value" white="0.24812825520833334" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                        </userDefinedRuntimeAttribute>
+                                                    </userDefinedRuntimeAttributes>
                                                 </textField>
                                                 <button hidden="YES" opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="trailing" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="JtN-An-cj9">
                                                     <rect key="frame" x="313" y="7" width="48" height="30"/>


### PR DESCRIPTION
Fixes #317

By definition, the UITextField placeholder text is a system provided color. This change appears to override it, but a) may not be officially supported/allowed and b) is imprecise because some additional alpha is being applied that I can't calculate.

![screen shot 2018-05-10 at 12 49 17 pm](https://user-images.githubusercontent.com/49511/39887932-ac39d09c-5450-11e8-8014-bc6fdcc9a0f2.png)

<img width="272" alt="screen shot 2018-05-10 at 12 49 58 pm" src="https://user-images.githubusercontent.com/49511/39887936-ada36484-5450-11e8-8fa7-ad086789fbe3.png">

