### PR TITLE
Settings button cut off in Account page (#337)

### DIFF
--- a/lockbox-ios/View/AccountSettingView.swift
+++ b/lockbox-ios/View/AccountSettingView.swift
@@ -70,15 +70,16 @@ extension AccountSettingView: UIGestureRecognizerDelegate {
 
         let leftButton = UIButton()
         leftButton.setTitle(Constant.string.settingsTitle, for: .normal)
+        leftButton.setTitleColor(.white, for: .normal)
+        leftButton.setTitleColor(Constant.color.lightGrey, for: .selected)
+        leftButton.setTitleColor(Constant.color.lightGrey, for: .highlighted)
+
         let backImage = UIImage(named: "back")
         leftButton.setImage(backImage, for: .normal)
         leftButton.adjustsImageWhenHighlighted = false
 
         leftButton.titleEdgeInsets = UIEdgeInsets(top: 0, left: 5, bottom: 0, right: -20)
-
-        leftButton.setTitleColor(.white, for: .normal)
-        leftButton.setTitleColor(Constant.color.lightGrey, for: .selected)
-        leftButton.setTitleColor(Constant.color.lightGrey, for: .highlighted)
+        leftButton.sizeToFit()
 
         self.navigationItem.leftBarButtonItem = UIBarButtonItem(customView: leftButton)
 


### PR DESCRIPTION
Resolves #337 

Apply sizeToFit to leftButton in setupNavBar method in
AccountSettingView.swift.  Set frame size when adding custom
UIButton in place of UIBarButtonItem (magpoc, 2012).

Reference:
magpoc. (2012, July 17). UIButton in UIBarButtonItem not showing up.
Message posted to https://stackoverflow.com/a/11514971/6084947