### PR TITLE
Fix some buildtime warnings

### DIFF
--- a/Lockbox.xcodeproj/project.pbxproj
+++ b/Lockbox.xcodeproj/project.pbxproj
@@ -837,7 +837,7 @@
 			attributes = {
 				LastSwiftUpdateCheck = 0900;
 				LastUpgradeCheck = 0930;
-				ORGANIZATIONNAME = "Sasha Heinen";
+				ORGANIZATIONNAME = Mozilla;
 				TargetAttributes = {
 					7D1B1AC31F99028D00C1F5FF = {
 						CreatedOnToolsVersion = 9.0;

--- a/lockbox-ios/Presenter/ItemListPresenter.swift
+++ b/lockbox-ios/Presenter/ItemListPresenter.swift
@@ -222,7 +222,7 @@ extension ItemListPresenter {
                         itemSortObservable,
                         syncStateObservable
                 )
-                .map { (latest: ([Login], ItemListFilterAction, ItemListSortingAction, SyncState)) -> LoginListTextSort in
+                .map { (latest: ([Login], ItemListFilterAction, ItemListSortingAction, SyncState)) -> LoginListTextSort in // swiftlint:disable:this line_length
                     return LoginListTextSort(
                             logins: latest.0,
                             text: latest.1.filteringText,

--- a/lockbox-ios/Presenter/WelcomePresenter.swift
+++ b/lockbox-ios/Presenter/WelcomePresenter.swift
@@ -116,7 +116,7 @@ class WelcomePresenter {
                 .map { $0.0 }
                 .flatMap { [weak self] latest -> Single<Void> in
                     if let target = self {
-                        return target.biometryManager.authenticateWithMessage(latest?.email ?? Constant.string.unlockPlaceholder)
+                        return target.biometryManager.authenticateWithMessage(latest?.email ?? Constant.string.unlockPlaceholder) // swiftlint:disable:this line_length
                                 .catchError { _ in
                                     // ignore errors from local authentication
                                     return Observable.never().asSingle()

--- a/lockbox-ios/Store/DataStore.swift
+++ b/lockbox-ios/Store/DataStore.swift
@@ -110,7 +110,7 @@ class DataStore {
         return self.storageStateSubject.asObservable()
     }
 
-    init(dispatcher: Dispatcher = Dispatcher.shared,
+    init(dispatcher: Dispatcher = Dispatcher.shared, // swiftlint:disable:this function_body_length
          profileFactory: @escaping ProfileFactory = defaultProfileFactory,
          fxaLoginHelper: FxALoginHelper = FxALoginHelper.sharedInstance,
          keychainWrapper: KeychainWrapper = KeychainWrapper.standard) {

--- a/lockbox-ios/Storyboard/Base.lproj/SettingList.storyboard
+++ b/lockbox-ios/Storyboard/Base.lproj/SettingList.storyboard
@@ -44,7 +44,7 @@
                                     </constraints>
                                 </view>
                                 <prototypes>
-                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" selectionStyle="blue" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" id="lSh-9i-9iX">
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" selectionStyle="blue" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" reuseIdentifier="settings-table-cell" id="lSh-9i-9iX">
                                         <rect key="frame" x="0.0" y="55.5" width="375" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="lSh-9i-9iX" id="IWo-bs-dQt">

--- a/lockbox-ios/Storyboard/ItemDetail.storyboard
+++ b/lockbox-ios/Storyboard/ItemDetail.storyboard
@@ -18,7 +18,7 @@
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="grouped" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="-1" estimatedSectionHeaderHeight="18" sectionFooterHeight="0.0" translatesAutoresizingMaskIntoConstraints="NO" id="4I2-rO-7Qh">
+                            <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="grouped" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="-1" sectionFooterHeight="0.0" translatesAutoresizingMaskIntoConstraints="NO" id="4I2-rO-7Qh">
                                 <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                                 <color key="backgroundColor" cocoaTouchSystemColor="groupTableViewBackgroundColor"/>
                                 <view key="tableFooterView" contentMode="scaleToFill" id="osx-2O-xPR">

--- a/lockbox-ios/View/FxAView.swift
+++ b/lockbox-ios/View/FxAView.swift
@@ -101,11 +101,11 @@ extension FxAView: WKScriptMessageHandler {
         // message is the same as the origin of the URL we initially loaded in this web view.
         // Note that this exploit wouldn't be possible if we were using WebChannels; see
         // https://developer.mozilla.org/en-US/docs/Mozilla/JavaScript_code_modules/WebChannel.jsm
-        //        let origin = message.frameInfo.securityOrigin
-        //        guard origin.`protocol` == url.scheme && origin.host == url.host && origin.port == (url.port ?? 0) else {
-        //            print("Ignoring message - \(origin) does not match expected origin \(url.origin)")
-        //            return
-        //        }
+        //   let origin = message.frameInfo.securityOrigin
+        //   guard origin.`protocol` == url.scheme && origin.host == url.host && origin.port == (url.port ?? 0) else {
+        //   print("Ignoring message - \(origin) does not match expected origin \(url.origin)")
+        //   return
+        //  }
 
         if message.name == "accountsCommandHandler" {
             let body = JSON(message.body)

--- a/lockbox-ios/View/ItemListView.swift
+++ b/lockbox-ios/View/ItemListView.swift
@@ -122,7 +122,7 @@ extension ItemListView: ItemListViewProtocol {
 }
 
 extension ItemListView {
-    fileprivate func setupDataSource() {
+    fileprivate func setupDataSource() { // swiftlint:disable:this function_body_length
         self.dataSource = RxTableViewSectionedAnimatedDataSource<ItemSectionModel>(
                 configureCell: { dataSource, tableView, path, _ in
                     let cellConfiguration = dataSource[path]


### PR DESCRIPTION
I recently spotted some of these in Xcode and figured if these are safe to fix then may as well clean them up. If better solutions exist then I'm open, just wanted to get these a bit more tidy so we didn't inadvertently start ignoring warnings...

@jhugman @sashei I poked around about the "Implicit import of bridging header... is deprecated" warning and wasn't sure how/what applied to our project and how to remedy it. In case you knew, thought it was a good idea to remove, and wanted to clear it on this branch while we're at it...