### PR TITLE
Update navigation bar action links

### DIFF
--- a/Lockbox.xcodeproj/project.pbxproj
+++ b/Lockbox.xcodeproj/project.pbxproj
@@ -20,6 +20,7 @@
 		391233892092155300CB0233 /* FxASignIn.js in Resources */ = {isa = PBXBuildFile; fileRef = 391233882092155300CB0233 /* FxASignIn.js */; };
 		39DB366B208E25710026DA92 /* Deferred.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 39B1508820878E42007497E5 /* Deferred.framework */; };
 		39DB366D208E25710026DA92 /* FxAUtils.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 39B1508620878E42007497E5 /* FxAUtils.framework */; };
+		4C61CC5120B4E47A001CE00E /* UIButton+Spec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C61CC5020B4E47A001CE00E /* UIButton+Spec.swift */; };
 		4C7F3C7D20B3C32A00C4C414 /* UIButton+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C7F3C7C20B3C32A00C4C414 /* UIButton+.swift */; };
 		7AA540053B184518789CDA12 /* ItemDetailActionSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7AA54A831379DFCD181B2362 /* ItemDetailActionSpec.swift */; };
 		7AA5400E231CF2E6FB1A5EEA /* ItemDetailStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7AA54E126924935F1ADF4E8E /* ItemDetailStore.swift */; };
@@ -226,6 +227,7 @@
 		39B1508820878E42007497E5 /* Deferred.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Deferred.framework; path = Carthage/Build/iOS/Deferred.framework; sourceTree = "<group>"; };
 		39DB3677208E2A800026DA92 /* Account.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Account.framework; path = Carthage/Build/iOS/Account.framework; sourceTree = "<group>"; };
 		39DB367D208E2F8F0026DA92 /* FxA.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = FxA.framework; path = Carthage/Build/iOS/FxA.framework; sourceTree = "<group>"; };
+		4C61CC5020B4E47A001CE00E /* UIButton+Spec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIButton+Spec.swift"; sourceTree = "<group>"; };
 		4C7F3C7C20B3C32A00C4C414 /* UIButton+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIButton+.swift"; sourceTree = "<group>"; };
 		7AA5404248F72FC87CC4978B /* Date+.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Date+.swift"; sourceTree = "<group>"; };
 		7AA5406822AB67B669BAF89B /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.info; path = Info.plist; sourceTree = "<group>"; };
@@ -677,6 +679,7 @@
 		7D1B1AC51F99028D00C1F5FF /* lockbox-iosTests */ = {
 			isa = PBXGroup;
 			children = (
+				4C61CC5020B4E47A001CE00E /* UIButton+Spec.swift */,
 				7DA4C6892028F86E00B61DD8 /* ItemListPresenterSpec.swift */,
 				7DA4C6872028F86E00B61DD8 /* ItemListViewSpec.swift */,
 				7DA4C6882028F86E00B61DD8 /* UIViewController+Spec.swift */,
@@ -1035,6 +1038,7 @@
 				7AA545D1DBB719E27B782966 /* ItemListDisplayActionSpec.swift in Sources */,
 				7AA54850D6DE1CD66D8C43AE /* UserInfoActionSpec.swift in Sources */,
 				7AA54E2C7C6639BCA7C37A1F /* AccountSettingPresenterSpec.swift in Sources */,
+				4C61CC5120B4E47A001CE00E /* UIButton+Spec.swift in Sources */,
 				7AA541ED07A75F27A211819B /* AccountSettingViewSpec.swift in Sources */,
 				D8783617207D70D100C19BC7 /* PreferredBrowserSettingPresenterSpec.swift in Sources */,
 				7AA54306397C76D229BA199A /* SettingActionSpec.swift in Sources */,

--- a/Lockbox.xcodeproj/project.pbxproj
+++ b/Lockbox.xcodeproj/project.pbxproj
@@ -20,6 +20,7 @@
 		391233892092155300CB0233 /* FxASignIn.js in Resources */ = {isa = PBXBuildFile; fileRef = 391233882092155300CB0233 /* FxASignIn.js */; };
 		39DB366B208E25710026DA92 /* Deferred.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 39B1508820878E42007497E5 /* Deferred.framework */; };
 		39DB366D208E25710026DA92 /* FxAUtils.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 39B1508620878E42007497E5 /* FxAUtils.framework */; };
+		4C7F3C7D20B3C32A00C4C414 /* UIButton+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4C7F3C7C20B3C32A00C4C414 /* UIButton+.swift */; };
 		7AA540053B184518789CDA12 /* ItemDetailActionSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7AA54A831379DFCD181B2362 /* ItemDetailActionSpec.swift */; };
 		7AA5400E231CF2E6FB1A5EEA /* ItemDetailStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7AA54E126924935F1ADF4E8E /* ItemDetailStore.swift */; };
 		7AA540CB2BA73DB82EDDAED1 /* SettingNavigationControllerSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7AA54E8C5A0848F0669FBB10 /* SettingNavigationControllerSpec.swift */; };
@@ -225,6 +226,7 @@
 		39B1508820878E42007497E5 /* Deferred.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Deferred.framework; path = Carthage/Build/iOS/Deferred.framework; sourceTree = "<group>"; };
 		39DB3677208E2A800026DA92 /* Account.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Account.framework; path = Carthage/Build/iOS/Account.framework; sourceTree = "<group>"; };
 		39DB367D208E2F8F0026DA92 /* FxA.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = FxA.framework; path = Carthage/Build/iOS/FxA.framework; sourceTree = "<group>"; };
+		4C7F3C7C20B3C32A00C4C414 /* UIButton+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIButton+.swift"; sourceTree = "<group>"; };
 		7AA5404248F72FC87CC4978B /* Date+.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Date+.swift"; sourceTree = "<group>"; };
 		7AA5406822AB67B669BAF89B /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.info; path = Info.plist; sourceTree = "<group>"; };
 		7AA5408D5D52952F11E20EEC /* BiometryManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BiometryManager.swift; sourceTree = "<group>"; };
@@ -605,6 +607,7 @@
 				7AA542A3362BE85B313A88B8 /* UIImage+.swift */,
 				7AA5404248F72FC87CC4978B /* Date+.swift */,
 				7AA54BF70B374C370B51ECB9 /* UIView+.swift */,
+				4C7F3C7C20B3C32A00C4C414 /* UIButton+.swift */,
 				7AA54D3C8D454F79BD580AAF /* UserDefaults+.swift */,
 				D86A307520829B7F00589CA8 /* UIApplication+.swift */,
 			);
@@ -1057,6 +1060,7 @@
 				7AA540D7395F48BD6983CC3E /* Dispatcher.swift in Sources */,
 				D8D029282064441600CC01C6 /* AutoLockSettingsView.swift in Sources */,
 				D831FEE0204C92CD00EAE19A /* SettingListPresenter.swift in Sources */,
+				4C7F3C7D20B3C32A00C4C414 /* UIButton+.swift in Sources */,
 				7DA4C6832028F84800B61DD8 /* ItemListView.swift in Sources */,
 				7AA54E03B01B57D89DE9CF6B /* Action.swift in Sources */,
 				7AA541B3BC9C4F5E6A725222 /* FxAView.swift in Sources */,

--- a/lockbox-ios/Common/Extensions/UIButton+.swift
+++ b/lockbox-ios/Common/Extensions/UIButton+.swift
@@ -22,10 +22,10 @@ extension UIButton {
         self.init()
 
         self.setTitle(title, for: .normal)
-        self.setTitleColor(.white, for: .normal)
-        self.setTitleColor(UIColor(white: 1.0, alpha: 0.6), for: .selected)
-        self.setTitleColor(UIColor(white: 1.0, alpha: 0.6), for: .highlighted)
-        self.setTitleColor(UIColor(white: 1.0, alpha: 0.6), for: .disabled)
+        self.setTitleColor(Constant.color.buttonTitleColorNormalState, for: .normal)
+        self.setTitleColor(Constant.color.buttonTitleColorOtherState, for: .selected)
+        self.setTitleColor(Constant.color.buttonTitleColorOtherState, for: .highlighted)
+        self.setTitleColor(Constant.color.buttonTitleColorOtherState, for: .disabled)
 
         if let name = imageName {
             let backImage = UIImage(named: name)?.withRenderingMode(.alwaysTemplate)

--- a/lockbox-ios/Common/Extensions/UIButton+.swift
+++ b/lockbox-ios/Common/Extensions/UIButton+.swift
@@ -23,8 +23,9 @@ extension UIButton {
 
         self.setTitle(title, for: .normal)
         self.setTitleColor(.white, for: .normal)
-        self.setTitleColor(Constant.color.lightGrey, for: .selected)
-        self.setTitleColor(Constant.color.lightGrey, for: .highlighted)
+        self.setTitleColor(UIColor(white: 1.0, alpha: 0.6), for: .selected)
+        self.setTitleColor(UIColor(white: 1.0, alpha: 0.6), for: .highlighted)
+        self.setTitleColor(UIColor(white: 1.0, alpha: 0.6), for: .disabled)
 
         if let name = imageName {
             let backImage = UIImage(named: name)

--- a/lockbox-ios/Common/Extensions/UIButton+.swift
+++ b/lockbox-ios/Common/Extensions/UIButton+.swift
@@ -28,9 +28,13 @@ extension UIButton {
         self.setTitleColor(UIColor(white: 1.0, alpha: 0.6), for: .disabled)
 
         if let name = imageName {
-            let backImage = UIImage(named: name)
+            let backImage = UIImage(named: name)?.withRenderingMode(.alwaysTemplate)
+            let tintedImage = backImage?.tinted(UIColor(white: 1.0, alpha: 0.6))
+            
             self.setImage(backImage, for: .normal)
-            self.adjustsImageWhenHighlighted = false
+            self.setImage(tintedImage, for: .selected)
+            self.setImage(tintedImage, for: .highlighted)
+            self.setImage(tintedImage, for: .disabled)
 
             self.titleEdgeInsets = UIEdgeInsets(top: 0, left: 5, bottom: 0, right: -20)
         }

--- a/lockbox-ios/Common/Extensions/UIButton+.swift
+++ b/lockbox-ios/Common/Extensions/UIButton+.swift
@@ -1,0 +1,39 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import UIKit
+
+extension UIButton {
+    /**
+     Initializes a new button with a title and an optional image. The title is
+     set to white in the normal state and light grey when selected or
+     highlighted. The image is set not to adjust when highlighted.  When an
+     image is set, a left edge inset of 5 and a right edge outset of 20 are
+     applied to the title.
+     
+     - Parameters:
+        - title: The title for the button
+        - imageName: The name of an image
+     
+     - Returns: A button with the title and image.
+     */
+    convenience init(title: String, imageName: String?) {
+        self.init()
+
+        self.setTitle(title, for: .normal)
+        self.setTitleColor(.white, for: .normal)
+        self.setTitleColor(Constant.color.lightGrey, for: .selected)
+        self.setTitleColor(Constant.color.lightGrey, for: .highlighted)
+
+        if let name = imageName {
+            let backImage = UIImage(named: name)
+            self.setImage(backImage, for: .normal)
+            self.adjustsImageWhenHighlighted = false
+
+            self.titleEdgeInsets = UIEdgeInsets(top: 0, left: 5, bottom: 0, right: -20)
+        }
+
+        self.sizeToFit()
+    }
+}

--- a/lockbox-ios/Common/Extensions/UIButton+.swift
+++ b/lockbox-ios/Common/Extensions/UIButton+.swift
@@ -36,9 +36,11 @@ extension UIButton {
             self.setImage(tintedImage, for: .highlighted)
             self.setImage(tintedImage, for: .disabled)
 
+            self.contentHorizontalAlignment = .left
             self.titleEdgeInsets = UIEdgeInsets(top: 0, left: 5, bottom: 0, right: -20)
         }
 
+        self.tintColor = .white
         self.sizeToFit()
     }
 }

--- a/lockbox-ios/Common/Extensions/UIButton+.swift
+++ b/lockbox-ios/Common/Extensions/UIButton+.swift
@@ -30,7 +30,7 @@ extension UIButton {
         if let name = imageName {
             let backImage = UIImage(named: name)?.withRenderingMode(.alwaysTemplate)
             let tintedImage = backImage?.tinted(UIColor(white: 1.0, alpha: 0.6))
-            
+
             self.setImage(backImage, for: .normal)
             self.setImage(tintedImage, for: .selected)
             self.setImage(tintedImage, for: .highlighted)

--- a/lockbox-ios/Common/Resources/Constants.swift
+++ b/lockbox-ios/Common/Resources/Constants.swift
@@ -24,6 +24,8 @@ struct Constant {
         static let kebabBlue = UIColor(hex: 0x003EAA)
         static let settingsHeader = UIColor(hex: 0x737373)
         static let tableViewCellHighlighted = UIColor(hex: 0xE5EFF9)
+        static let buttonTitleColorNormalState = UIColor.white
+        static let buttonTitleColorOtherState = UIColor(white: 1.0, alpha: 0.6)
     }
 
     struct fxa {

--- a/lockbox-ios/Common/Resources/Constants.swift
+++ b/lockbox-ios/Common/Resources/Constants.swift
@@ -38,6 +38,7 @@ struct Constant {
         static let aToZ = NSLocalizedString("a_to_z", value: "A-Z", comment: "Label for the button allowing users to sort an entry list alphabetically")
         static let back = NSLocalizedString("back", value: "Back", comment: "Back button title")
         static let cancel = NSLocalizedString("cancel", value: "Cancel", comment: "Cancel button title")
+        static let close = NSLocalizedString("close", value: "Close", comment: "Close button title")
         static let unlink = NSLocalizedString("unlink", value: "Disconnect", comment: "Unlink aka Disconnect button title")
         static let done = NSLocalizedString("done", value: "Done", comment: "Text on button to close settings")
         static let confirmDialogTitle = NSLocalizedString("confirm_dialog_title", value: "Disconnect Firefox Lockbox?", comment: "Confirm dialog title")

--- a/lockbox-ios/Presenter/AutoLockSettingsPresenter.swift
+++ b/lockbox-ios/Presenter/AutoLockSettingsPresenter.swift
@@ -69,4 +69,10 @@ class AutoLockSettingPresenter {
 
         view.bind(items: driver)
     }
+
+    lazy private(set) var onSettingsTap: AnyObserver<Void> = {
+        return Binder(self) { target, _ in
+            target.routeActionHandler.invoke(SettingRouteAction.list)
+            }.asObserver()
+    }()
 }

--- a/lockbox-ios/Presenter/FxAPresenter.swift
+++ b/lockbox-ios/Presenter/FxAPresenter.swift
@@ -28,7 +28,7 @@ class FxAPresenter {
 
     private var disposeBag = DisposeBag()
 
-    public var onCancel: AnyObserver<Void> {
+    public var onClose: AnyObserver<Void> {
         return Binder(self) { target, _ in
             target.routeActionHandler.invoke(LoginRouteAction.welcome)
         }.asObserver()

--- a/lockbox-ios/Presenter/PreferredBrowserSettingPresenter.swift
+++ b/lockbox-ios/Presenter/PreferredBrowserSettingPresenter.swift
@@ -72,4 +72,10 @@ class PreferredBrowserSettingPresenter {
 
         view?.bind(items: driver)
     }
+
+    lazy private(set) var onSettingsTap: AnyObserver<Void> = {
+        return Binder(self) { target, _ in
+            target.routeActionHandler.invoke(SettingRouteAction.list)
+            }.asObserver()
+    }()
 }

--- a/lockbox-ios/View/AccountSettingView.swift
+++ b/lockbox-ios/View/AccountSettingView.swift
@@ -69,33 +69,21 @@ extension AccountSettingView: UIGestureRecognizerDelegate {
             NSAttributedStringKey.font: UIFont.systemFont(ofSize: 18, weight: .semibold)
         ]
 
-        let leftButton = UIButton()
-        leftButton.setTitle(Constant.string.settingsTitle, for: .normal)
-        leftButton.setTitleColor(.white, for: .normal)
-        leftButton.setTitleColor(Constant.color.lightGrey, for: .selected)
-        leftButton.setTitleColor(Constant.color.lightGrey, for: .highlighted)
-
-        let backImage = UIImage(named: "back")
-        leftButton.setImage(backImage, for: .normal)
-        leftButton.adjustsImageWhenHighlighted = false
-
-        leftButton.titleEdgeInsets = UIEdgeInsets(top: 0, left: 5, bottom: 0, right: -20)
-        leftButton.sizeToFit()
-
+        let leftButton = UIButton(title: Constant.string.settingsTitle, imageName: "back")
         self.navigationItem.leftBarButtonItem = UIBarButtonItem(customView: leftButton)
 
         if let presenter = self.presenter {
             leftButton.rx.tap
-                    .bind(to: presenter.onSettingsTap)
-                    .disposed(by: self.disposeBag)
+                .bind(to: presenter.onSettingsTap)
+                .disposed(by: self.disposeBag)
 
             self.navigationController?.interactivePopGestureRecognizer?.delegate = self
             self.navigationController?.interactivePopGestureRecognizer?.rx.event
-                    .map { _ -> Void in
-                        return ()
-                    }
-                    .bind(to: presenter.onSettingsTap)
-                    .disposed(by: self.disposeBag)
+                .map { _ -> Void in
+                    return ()
+                }
+                .bind(to: presenter.onSettingsTap)
+                .disposed(by: self.disposeBag)
         }
     }
 }

--- a/lockbox-ios/View/AutoLockSettingsView.swift
+++ b/lockbox-ios/View/AutoLockSettingsView.swift
@@ -54,31 +54,6 @@ class AutoLockSettingView: UITableViewController {
 }
 
 extension AutoLockSettingView {
-//    private func setupNavbar() {
-//        self.navigationItem.title = Constant.string.settingsAutoLock
-//        self.navigationController?.navigationBar.titleTextAttributes = [
-//            NSAttributedStringKey.foregroundColor: UIColor.white,
-//            NSAttributedStringKey.font: UIFont.systemFont(ofSize: 18, weight: .semibold)
-//        ]
-//
-//        let leftButton = UIButton(title: Constant.string.settingsTitle, imageName: "back")
-//        self.navigationItem.leftBarButtonItem = UIBarButtonItem(customView: leftButton)
-//
-//        if let presenter = self.presenter {
-//            leftButton.rx.tap
-//                .bind(to: presenter.onSettingsTap)
-//                .disposed(by: self.disposeBag)
-//
-//            self.navigationController?.interactivePopGestureRecognizer?.delegate = self
-//            self.navigationController?.interactivePopGestureRecognizer?.rx.event
-//                .map { _ -> Void in
-//                    return ()
-//                }
-//                .bind(to: presenter.onSettingsTap)
-//                .disposed(by: self.disposeBag)
-//        }
-//    }
-
     private func setupFooter() {
         self.tableView.tableFooterView = UIView()
     }

--- a/lockbox-ios/View/AutoLockSettingsView.swift
+++ b/lockbox-ios/View/AutoLockSettingsView.swift
@@ -54,9 +54,30 @@ class AutoLockSettingView: UITableViewController {
 }
 
 extension AutoLockSettingView {
-    private func setupNavbar() {
-        navigationItem.title = Constant.string.settingsAutoLock
-    }
+//    private func setupNavbar() {
+//        self.navigationItem.title = Constant.string.settingsAutoLock
+//        self.navigationController?.navigationBar.titleTextAttributes = [
+//            NSAttributedStringKey.foregroundColor: UIColor.white,
+//            NSAttributedStringKey.font: UIFont.systemFont(ofSize: 18, weight: .semibold)
+//        ]
+//
+//        let leftButton = UIButton(title: Constant.string.settingsTitle, imageName: "back")
+//        self.navigationItem.leftBarButtonItem = UIBarButtonItem(customView: leftButton)
+//
+//        if let presenter = self.presenter {
+//            leftButton.rx.tap
+//                .bind(to: presenter.onSettingsTap)
+//                .disposed(by: self.disposeBag)
+//
+//            self.navigationController?.interactivePopGestureRecognizer?.delegate = self
+//            self.navigationController?.interactivePopGestureRecognizer?.rx.event
+//                .map { _ -> Void in
+//                    return ()
+//                }
+//                .bind(to: presenter.onSettingsTap)
+//                .disposed(by: self.disposeBag)
+//        }
+//    }
 
     private func setupFooter() {
         self.tableView.tableFooterView = UIView()
@@ -94,6 +115,33 @@ extension AutoLockSettingView: AutoLockSettingViewProtocol {
             items
                     .drive(self.tableView.rx.items(dataSource: dataSource))
                     .disposed(by: self.disposeBag)
+        }
+    }
+}
+
+extension AutoLockSettingView: UIGestureRecognizerDelegate {
+    private func setupNavbar() {
+        self.navigationItem.title = Constant.string.settingsAutoLock
+        self.navigationController?.navigationBar.titleTextAttributes = [
+            NSAttributedStringKey.foregroundColor: UIColor.white,
+            NSAttributedStringKey.font: UIFont.systemFont(ofSize: 18, weight: .semibold)
+        ]
+
+        let leftButton = UIButton(title: Constant.string.settingsTitle, imageName: "back")
+        self.navigationItem.leftBarButtonItem = UIBarButtonItem(customView: leftButton)
+
+        if let presenter = self.presenter {
+            leftButton.rx.tap
+                .bind(to: presenter.onSettingsTap)
+                .disposed(by: self.disposeBag)
+
+            self.navigationController?.interactivePopGestureRecognizer?.delegate = self
+            self.navigationController?.interactivePopGestureRecognizer?.rx.event
+                .map { _ -> Void in
+                    return ()
+                }
+                .bind(to: presenter.onSettingsTap)
+                .disposed(by: self.disposeBag)
         }
     }
 }

--- a/lockbox-ios/View/FxAView.swift
+++ b/lockbox-ios/View/FxAView.swift
@@ -28,37 +28,13 @@ class FxAView: UIViewController, FxAViewProtocol, WKNavigationDelegate {
         self.configureWebView()
         self.webView.navigationDelegate = self
         self.view = self.webView
-        self.styleNavigationBar()
+        self.setupNavBar()
 
         self.presenter?.onViewReady()
     }
 
     func loadRequest(_ urlRequest: URLRequest) {
         self.webView.load(urlRequest)
-    }
-
-    private func styleNavigationBar() {
-        self.navigationItem.leftBarButtonItem = UIBarButtonItem(
-                title: Constant.string.close,
-                style: .plain,
-                target: nil,
-                action: nil
-        )
-
-        self.navigationItem.leftBarButtonItem!.setTitleTextAttributes([
-            NSAttributedStringKey.foregroundColor: UIColor.white,
-            NSAttributedStringKey.font: UIFont.systemFont(ofSize: 18)
-        ], for: .normal)
-
-        if #available(iOS 11.0, *) {
-            self.navigationItem.largeTitleDisplayMode = .never
-        }
-
-        if let presenter = self.presenter {
-            self.navigationItem.leftBarButtonItem!.rx.tap
-                    .bind(to: presenter.onClose)
-                    .disposed(by: self.disposeBag)
-        }
     }
 
     required init?(coder aDecoder: NSCoder) {
@@ -172,5 +148,30 @@ class LeakAvoider: NSObject, WKScriptMessageHandler {
 
     func userContentController(_ userContentController: WKUserContentController, didReceive message: WKScriptMessage) {
         self.delegate?.userContentController(userContentController, didReceive: message)
+    }
+}
+
+extension FxAView: UIGestureRecognizerDelegate {
+    fileprivate func setupNavBar() {
+        let leftButton = UIButton(title: Constant.string.close, imageName: nil)
+        self.navigationItem.leftBarButtonItem = UIBarButtonItem(customView: leftButton)
+
+        if #available(iOS 11.0, *) {
+            self.navigationItem.largeTitleDisplayMode = .never
+        }
+
+        if let presenter = self.presenter {
+            leftButton.rx.tap
+                .bind(to: presenter.onClose)
+                .disposed(by: self.disposeBag)
+
+            self.navigationController?.interactivePopGestureRecognizer?.delegate = self
+            self.navigationController?.interactivePopGestureRecognizer?.rx.event
+                .map { _ -> Void in
+                    return ()
+                }
+                .bind(to: presenter.onClose)
+                .disposed(by: self.disposeBag)
+        }
     }
 }

--- a/lockbox-ios/View/FxAView.swift
+++ b/lockbox-ios/View/FxAView.swift
@@ -39,7 +39,7 @@ class FxAView: UIViewController, FxAViewProtocol, WKNavigationDelegate {
 
     private func styleNavigationBar() {
         self.navigationItem.leftBarButtonItem = UIBarButtonItem(
-                title: Constant.string.cancel,
+                title: Constant.string.close,
                 style: .plain,
                 target: nil,
                 action: nil
@@ -56,7 +56,7 @@ class FxAView: UIViewController, FxAViewProtocol, WKNavigationDelegate {
 
         if let presenter = self.presenter {
             self.navigationItem.leftBarButtonItem!.rx.tap
-                    .bind(to: presenter.onCancel)
+                    .bind(to: presenter.onClose)
                     .disposed(by: self.disposeBag)
         }
     }

--- a/lockbox-ios/View/ItemDetailView.swift
+++ b/lockbox-ios/View/ItemDetailView.swift
@@ -83,31 +83,7 @@ extension ItemDetailView: ItemDetailViewProtocol {
 // view styling
 extension ItemDetailView: UIGestureRecognizerDelegate {
     fileprivate func setupNavigation() {
-        let leftButton = UIButton()
-        leftButton.adjustsImageWhenHighlighted = false
-
-        let leftImage = UIImage(named: "back")?.withRenderingMode(.alwaysTemplate)
-        leftButton.setImage(leftImage, for: .normal)
-        leftButton.setTitle(Constant.string.back, for: .normal)
-
-        leftButton.contentHorizontalAlignment = .left
-        leftButton.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
-        leftButton.titleEdgeInsets = UIEdgeInsets(top: 0, left: 5, bottom: 0, right: -20)
-        leftButton.setTitleColor(.white, for: .normal)
-        leftButton.setTitleColor(UIColor(white: 1.0, alpha: 0.6), for: .selected)
-        leftButton.setTitleColor(UIColor(white: 1.0, alpha: 0.6), for: .highlighted)
-        leftButton.tintColor = .white
-
-        leftButton.addConstraint(NSLayoutConstraint(
-            item: leftButton,
-            attribute: .width,
-            relatedBy: .equal,
-            toItem: nil,
-            attribute: .notAnAttribute,
-            multiplier: 1.0,
-            constant: 100)
-        )
-
+        let leftButton = UIButton(title: Constant.string.back, imageName: "back")
         self.navigationItem.leftBarButtonItem = UIBarButtonItem(customView: leftButton)
 
         if #available(iOS 11.0, *) {

--- a/lockbox-ios/View/ItemDetailView.swift
+++ b/lockbox-ios/View/ItemDetailView.swift
@@ -89,6 +89,12 @@ extension ItemDetailView: UIGestureRecognizerDelegate {
         if #available(iOS 11.0, *) {
             self.navigationItem.largeTitleDisplayMode = .always
         }
+        
+        self.navigationController?.navigationBar.tintColor = UIColor.white
+        self.navigationController?.navigationBar.titleTextAttributes = [
+            NSAttributedStringKey.foregroundColor: UIColor.white,
+            NSAttributedStringKey.font: UIFont.systemFont(ofSize: 18, weight: .semibold)
+        ]
 
         if let presenter = self.presenter {
             leftButton.rx.tap

--- a/lockbox-ios/View/ItemDetailView.swift
+++ b/lockbox-ios/View/ItemDetailView.swift
@@ -89,7 +89,7 @@ extension ItemDetailView: UIGestureRecognizerDelegate {
         if #available(iOS 11.0, *) {
             self.navigationItem.largeTitleDisplayMode = .always
         }
-        
+
         self.navigationController?.navigationBar.tintColor = UIColor.white
         self.navigationController?.navigationBar.titleTextAttributes = [
             NSAttributedStringKey.foregroundColor: UIColor.white,

--- a/lockbox-ios/View/ItemListView.swift
+++ b/lockbox-ios/View/ItemListView.swift
@@ -276,6 +276,17 @@ extension ItemListView {
 
     private var sortingButton: UIButton {
         let button = UIButton(title: Constant.string.aToZ, imageName: "down-caret")
+        // custom width constraint so "Recent" fits on small iPhone SE screen
+        button.translatesAutoresizingMaskIntoConstraints = false
+        button.addConstraint(NSLayoutConstraint(
+            item: button,
+            attribute: .width,
+            relatedBy: .equal,
+            toItem: nil,
+            attribute: .notAnAttribute,
+            multiplier: 1.0,
+            constant: 60)
+        )
         return button
     }
 }

--- a/lockbox-ios/View/ItemListView.swift
+++ b/lockbox-ios/View/ItemListView.swift
@@ -265,10 +265,11 @@ extension ItemListView {
     private var prefButton: UIButton {
         let button = UIButton()
         let prefImage = UIImage(named: "preferences")?.withRenderingMode(.alwaysTemplate)
-        let tintedPrefImage = prefImage?.tinted(Constant.color.lightGrey)
+        let tintedPrefImage = prefImage?.tinted(UIColor(white: 1.0, alpha: 0.6))
         button.setImage(prefImage, for: .normal)
         button.setImage(tintedPrefImage, for: .selected)
         button.setImage(tintedPrefImage, for: .highlighted)
+        button.setImage(tintedPrefImage, for: .disabled)
         button.tintColor = .white
         button.translatesAutoresizingMaskIntoConstraints = false
         return button

--- a/lockbox-ios/View/ItemListView.swift
+++ b/lockbox-ios/View/ItemListView.swift
@@ -265,7 +265,7 @@ extension ItemListView {
     private var prefButton: UIButton {
         let button = UIButton()
         let prefImage = UIImage(named: "preferences")?.withRenderingMode(.alwaysTemplate)
-        let tintedPrefImage = prefImage?.tinted(UIColor(white: 1.0, alpha: 0.6))
+        let tintedPrefImage = prefImage?.tinted(Constant.color.lightGrey)
         button.setImage(prefImage, for: .normal)
         button.setImage(tintedPrefImage, for: .selected)
         button.setImage(tintedPrefImage, for: .highlighted)
@@ -275,32 +275,7 @@ extension ItemListView {
     }
 
     private var sortingButton: UIButton {
-        let button = UIButton()
-        button.adjustsImageWhenHighlighted = false
-
-        let sortingImage = UIImage(named: "down-caret")?.withRenderingMode(.alwaysTemplate)
-        button.setImage(sortingImage, for: .normal)
-        button.setTitle(Constant.string.aToZ, for: .normal)
-
-        button.contentHorizontalAlignment = .left
-        button.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
-        button.titleEdgeInsets = UIEdgeInsets(top: 0, left: 5, bottom: 0, right: -20)
-        button.setTitleColor(.white, for: .normal)
-        button.setTitleColor(UIColor(white: 1.0, alpha: 0.6), for: .highlighted)
-        button.setTitleColor(UIColor(white: 1.0, alpha: 0.6), for: .selected)
-        button.setTitleColor(UIColor(white: 1.0, alpha: 0.6), for: .disabled)
-        button.tintColor = .white
-        button.translatesAutoresizingMaskIntoConstraints = false
-
-        button.addConstraint(NSLayoutConstraint(
-                item: button,
-                attribute: .width,
-                relatedBy: .equal,
-                toItem: nil,
-                attribute: .notAnAttribute,
-                multiplier: 1.0,
-                constant: 100)
-        )
+        let button = UIButton(title: Constant.string.aToZ, imageName: "down-caret")
         return button
     }
 }

--- a/lockbox-ios/View/PreferredBrowserSettingView.swift
+++ b/lockbox-ios/View/PreferredBrowserSettingView.swift
@@ -48,17 +48,6 @@ class PreferredBrowserSettingView: UITableViewController {
 }
 
 extension PreferredBrowserSettingView {
-//    private func setupNavbar() {
-//        self.navigationItem.title = Constant.string.settingsBrowser
-//        self.navigationController?.navigationBar.titleTextAttributes = [
-//            NSAttributedStringKey.foregroundColor: UIColor.white,
-//            NSAttributedStringKey.font: UIFont.systemFont(ofSize: 18, weight: .semibold)
-//        ]
-//
-//        let leftButton = UIButton(title: Constant.string.settingsTitle, imageName: "back")
-//        self.navigationItem.leftBarButtonItem = UIBarButtonItem(customView: leftButton)
-//    }
-
     private func setupFooter() {
         self.tableView.tableFooterView = UIView()
     }

--- a/lockbox-ios/View/PreferredBrowserSettingView.swift
+++ b/lockbox-ios/View/PreferredBrowserSettingView.swift
@@ -48,9 +48,16 @@ class PreferredBrowserSettingView: UITableViewController {
 }
 
 extension PreferredBrowserSettingView {
-    private func setupNavbar() {
-        navigationItem.title = Constant.string.settingsBrowser
-    }
+//    private func setupNavbar() {
+//        self.navigationItem.title = Constant.string.settingsBrowser
+//        self.navigationController?.navigationBar.titleTextAttributes = [
+//            NSAttributedStringKey.foregroundColor: UIColor.white,
+//            NSAttributedStringKey.font: UIFont.systemFont(ofSize: 18, weight: .semibold)
+//        ]
+//
+//        let leftButton = UIButton(title: Constant.string.settingsTitle, imageName: "back")
+//        self.navigationItem.leftBarButtonItem = UIBarButtonItem(customView: leftButton)
+//    }
 
     private func setupFooter() {
         self.tableView.tableFooterView = UIView()
@@ -91,6 +98,33 @@ extension PreferredBrowserSettingView: PreferredBrowserSettingViewProtocol {
         if let dataSource = dataSource {
             items
                 .drive(self.tableView.rx.items(dataSource: dataSource))
+                .disposed(by: self.disposeBag)
+        }
+    }
+}
+
+extension PreferredBrowserSettingView: UIGestureRecognizerDelegate {
+    private func setupNavbar() {
+        self.navigationItem.title = Constant.string.settingsBrowser
+        self.navigationController?.navigationBar.titleTextAttributes = [
+            NSAttributedStringKey.foregroundColor: UIColor.white,
+            NSAttributedStringKey.font: UIFont.systemFont(ofSize: 18, weight: .semibold)
+        ]
+
+        let leftButton = UIButton(title: Constant.string.settingsTitle, imageName: "back")
+        self.navigationItem.leftBarButtonItem = UIBarButtonItem(customView: leftButton)
+
+        if let presenter = self.presenter {
+            leftButton.rx.tap
+                .bind(to: presenter.onSettingsTap)
+                .disposed(by: self.disposeBag)
+
+            self.navigationController?.interactivePopGestureRecognizer?.delegate = self
+            self.navigationController?.interactivePopGestureRecognizer?.rx.event
+                .map { _ -> Void in
+                    return ()
+                }
+                .bind(to: presenter.onSettingsTap)
                 .disposed(by: self.disposeBag)
         }
     }

--- a/lockbox-iosTests/FxAPresenterSpec.swift
+++ b/lockbox-iosTests/FxAPresenterSpec.swift
@@ -88,9 +88,9 @@ class FxAPresenterSpec: QuickSpec {
                 }
             }
 
-            describe("onCancel") {
+            describe("onClose") {
                 beforeEach {
-                    self.subject.onCancel.onNext(())
+                    self.subject.onClose.onNext(())
                 }
 
                 it("routes back to login") {

--- a/lockbox-iosTests/UIButton+Spec.swift
+++ b/lockbox-iosTests/UIButton+Spec.swift
@@ -1,0 +1,67 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import UIKit
+import Quick
+import Nimble
+
+@testable import Lockbox
+
+class UIButtonSpec: QuickSpec {
+    var subject: UIButton!
+
+    override func spec() {
+        beforeEach {
+            self.subject = UIButton(title: "title", imageName: "back")
+        }
+
+        describe("UIButton") {
+            describe("button with title and image convenience init") {
+                it("correctly sets title color for normal state") {
+                    let normalColor = self.subject.titleColor(for: .normal)
+                    let expectedColor = Constant.color.buttonTitleColorNormalState
+                    expect(normalColor).to(equal(expectedColor))
+                }
+
+                it("correctly sets title color for selected state") {
+                    let selectedColor = self.subject.titleColor(for: .selected)
+                    let expectedColor = Constant.color.buttonTitleColorOtherState
+                    expect(selectedColor).to(equal(expectedColor))
+                }
+
+                it("correctly sets title color for highlighted state") {
+                    let highlightedColor = self.subject.titleColor(for: .highlighted)
+                    let expectedColor = Constant.color.buttonTitleColorOtherState
+                    expect(highlightedColor).to(equal(expectedColor))
+                }
+
+                it("correctly sets title color for disabled state") {
+                    let disabledColor = self.subject.titleColor(for: .disabled)
+                    let expectedColor = Constant.color.buttonTitleColorOtherState
+                    expect(disabledColor).to(equal(expectedColor))
+                }
+
+                it("is able to set a normal image using the 'back' image") {
+                    let normalImage = self.subject.image(for: .normal)
+                    expect(normalImage).toNot(beNil())
+                }
+
+                it("is able to set a selected image using the 'back' image") {
+                    let selectedImage = self.subject.image(for: .selected)
+                    expect(selectedImage).toNot(beNil())
+                }
+
+                it("is able to set a highlighted image using the 'back' image") {
+                    let highlightedImage = self.subject.image(for: .highlighted)
+                    expect(highlightedImage).toNot(beNil())
+                }
+
+                it("is able to set a disabled image using the 'back' image") {
+                    let disabledImage = self.subject.image(for: .disabled)
+                    expect(disabledImage).toNot(beNil())
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Make style of left bar button in navigation bar consistent.  Use
UIButton extension to style title and image.  Update presenters for use
with extension.

Resolve #251 issues:

* "Cancel" action link in FxA authentication screens + update text to
  "Close" (also update style to be consistent)
* Settings icon on Entry List screen (previously addressed; only update
  style to be consistent)
* Down caret icon (in sort) on Entry List screen (previously addressed;
  only update style to be consistent)
* Back chevron icon on Entry Detail screen (previously addressed; only
  update style to be consistent)

Update style to be consistent for the following views:
* account setting
* autolock setting
* preference browser setting

Update FxA property to onClose from onCancel including in presenter and spec.