### PR TITLE
Expand www title to include optional digits afterwards

### DIFF
--- a/lockbox-ios/Common/Extensions/String+.swift
+++ b/lockbox-ios/Common/Extensions/String+.swift
@@ -20,7 +20,7 @@ extension String {
         return self
                 .replacingOccurrences(of: "^http://", with: "", options: .regularExpression)
                 .replacingOccurrences(of: "^https://", with: "", options: .regularExpression)
-                .replacingOccurrences(of: "^www.", with: "", options: .regularExpression)
+                .replacingOccurrences(of: "^www\\d*.", with: "", options: .regularExpression)
     }
 
     private func sha256(_ data: Data) -> Data? {

--- a/lockbox-ios/Common/Extensions/String+.swift
+++ b/lockbox-ios/Common/Extensions/String+.swift
@@ -20,7 +20,7 @@ extension String {
         return self
                 .replacingOccurrences(of: "^http://", with: "", options: .regularExpression)
                 .replacingOccurrences(of: "^https://", with: "", options: .regularExpression)
-                .replacingOccurrences(of: "^www\\d*.", with: "", options: .regularExpression)
+                .replacingOccurrences(of: "^www\\d*\\.", with: "", options: .regularExpression)
     }
 
     private func sha256(_ data: Data) -> Data? {

--- a/lockbox-iosTests/String+Spec.swift
+++ b/lockbox-iosTests/String+Spec.swift
@@ -29,6 +29,8 @@ class StringSpec: QuickSpec {
                 expect("www.bats.com".titleFromHostname()).to(equal("bats.com"))
                 expect("https://hey.http://.com".titleFromHostname()).to(equal("hey.http://.com"))
                 expect("http://www.maps.com".titleFromHostname()).to(equal("maps.com"))
+                expect("http://www2.stuff.example".titleFromHostname()).to(equal("stuff.example"))
+                expect("http://www-api.maps.com".titleFromHostname()).to(equal("www-api.maps.com"))
             }
         }
     }

--- a/lockbox-iosTests/String+Spec.swift
+++ b/lockbox-iosTests/String+Spec.swift
@@ -30,6 +30,8 @@ class StringSpec: QuickSpec {
                 expect("https://hey.http://.com".titleFromHostname()).to(equal("hey.http://.com"))
                 expect("http://www.maps.com".titleFromHostname()).to(equal("maps.com"))
                 expect("http://www2.stuff.example".titleFromHostname()).to(equal("stuff.example"))
+                expect("http://www12345.stuff.example".titleFromHostname()).to(equal("stuff.example"))
+                expect("http://www2api.stuff.example".titleFromHostname()).to(equal("www2api.stuff.example"))
                 expect("http://www-api.maps.com".titleFromHostname()).to(equal("www-api.maps.com"))
             }
         }


### PR DESCRIPTION
Fixes #432
Follow up to #193 #380

Before: `www1.bmo.com` became `.bmo.com`
Now: `www1.bmo.com` becomes `bmo.com`

<img width="380" alt="screen shot 2018-05-24 at 8 11 59 am" src="https://user-images.githubusercontent.com/49511/40491029-4bdf977e-5f2a-11e8-8340-3a390ef9df98.png">

This will replace 0, 1, or any number of digits (www, www1, www12, www123).

<img width="306" alt="screen shot 2018-05-24 at 8 07 52 am" src="https://user-images.githubusercontent.com/49511/40491047-513a56a0-5f2a-11e8-8f9d-2de6613f0b01.png">
