### PR TITLE
Remove onAppExit autolock setting for initial release

### DIFF
--- a/lockbox-ios/Common/Resources/Constants.swift
+++ b/lockbox-ios/Common/Resources/Constants.swift
@@ -70,7 +70,6 @@ struct Constant {
         static let settingsAccount = NSLocalizedString("settings.account", value: "Account", comment: "Account option in settings")
         static let settingsAutoLock = NSLocalizedString("settings.autoLock", value: "Auto Lock", comment: "Auto Lock option in settings")
         static let settingsBrowser = NSLocalizedString("settings.browser", value: "Open Websites in", comment: "Preferred Browser option in settings")
-        static let autoLockOnAppExit = NSLocalizedString("settings.autoLock.onAppExit", value: "On app exit", comment: "On app exit auto lock setting")
         static let autoLockOneMinute = NSLocalizedString("settings.autoLock.oneMinute", value: "1 minute", comment: "1 minute auto lock setting")
         static let autoLockFiveMinutes = NSLocalizedString("settings.autoLock.fiveMinutes", value: "5 minutes", comment: "5 minutes auto lock setting")
         static let autoLockThirtyMinutes = NSLocalizedString("settings.autoLock.thirtyMinutes", value: "30 minutes", comment: "30 minutes auto lock setting")

--- a/lockbox-ios/Presenter/AutoLockSettingsPresenter.swift
+++ b/lockbox-ios/Presenter/AutoLockSettingsPresenter.swift
@@ -19,8 +19,6 @@ class AutoLockSettingPresenter {
     private var disposeBag = DisposeBag()
 
     lazy var initialSettings = [
-        CheckmarkSettingCellConfiguration(text: Constant.string.autoLockOnAppExit, isChecked: false,
-                                          valueWhenChecked: AutoLockSetting.OnAppExit),
         CheckmarkSettingCellConfiguration(text: Constant.string.autoLockOneMinute, isChecked: false,
                                           valueWhenChecked: AutoLockSetting.OneMinute),
         CheckmarkSettingCellConfiguration(text: Constant.string.autoLockFiveMinutes, isChecked: false,

--- a/lockbox-ios/Presenter/RootPresenter.swift
+++ b/lockbox-ios/Presenter/RootPresenter.swift
@@ -238,8 +238,6 @@ extension RootPresenter {
                 .take(1)
                 .subscribe(onNext: { autoLockSetting in
                     switch autoLockSetting {
-                    case .OnAppExit:
-                        self.dataStoreActionHandler.invoke(.lock)
                     case .Never:
                         self.dataStoreActionHandler.invoke(.unlock)
                     default:

--- a/lockbox-ios/Store/AutoLockStore.swift
+++ b/lockbox-ios/Store/AutoLockStore.swift
@@ -59,14 +59,7 @@ class AutoLockStore {
                 .disposed(by: self.disposeBag)
     }
 
-    private func lifecycleAction(evt: Event<LifecycleAction>) {
-        if evt.element == .background {
-            self.userDefaults.onAutoLockTime
-                    .take(1)
-                    .subscribe(onNext: { (latest: AutoLockSetting) in })
-                    .disposed(by: self.disposeBag)
-        }
-    }
+    private func lifecycleAction(evt: Event<LifecycleAction>) {}
 
     private func resetTimer() {
         self.stopTimer()

--- a/lockbox-ios/Store/AutoLockStore.swift
+++ b/lockbox-ios/Store/AutoLockStore.swift
@@ -63,11 +63,7 @@ class AutoLockStore {
         if evt.element == .background {
             self.userDefaults.onAutoLockTime
                     .take(1)
-                    .subscribe(onNext: { (latest: AutoLockSetting) in
-                        if latest == AutoLockSetting.OnAppExit {
-                            self.lockApp()
-                        }
-                    })
+                    .subscribe(onNext: { (latest: AutoLockSetting) in })
                     .disposed(by: self.disposeBag)
         }
     }
@@ -94,9 +90,8 @@ class AutoLockStore {
                         self.setTimer(seconds: 60 * 60 * 24)
                     case .Never:
                         self.stopTimer()
-                    case .OnAppExit:
-                        return
                     }
+                    return
                 })
                 .disposed(by: self.disposeBag)
     }

--- a/lockbox-ios/Store/UserInfoStore.swift
+++ b/lockbox-ios/Store/UserInfoStore.swift
@@ -97,7 +97,6 @@ extension UserInfoStore {
 }
 
 enum AutoLockSetting: String {
-    case OnAppExit
     case OneMinute
     case FiveMinutes
     case OneHour
@@ -107,8 +106,6 @@ enum AutoLockSetting: String {
 
     func toString() -> String {
         switch self {
-        case .OnAppExit:
-            return Constant.string.autoLockOnAppExit
         case .FiveMinutes:
             return Constant.string.autoLockFiveMinutes
         case .Never:

--- a/lockbox-iosTests/AutoLockSettingsPresenterSpec.swift
+++ b/lockbox-iosTests/AutoLockSettingsPresenterSpec.swift
@@ -69,7 +69,7 @@ class AutoLockSettingsPresenterSpec: QuickSpec {
                     }
                 }
                 expect(settings.count).to(be(1))
-                expect(settings[0].items.count).to(be(7))
+                expect(settings[0].items.count).to(be(6))
             } else {
                 fail("settings not set in onViewReady")
             }

--- a/lockbox-iosTests/AutoLockStoreSpec.swift
+++ b/lockbox-iosTests/AutoLockStoreSpec.swift
@@ -67,18 +67,6 @@ class AutoLockStoreSpec: QuickSpec {
             }
 
             describe("backgrounding app") {
-                describe("with auto lock setting on OnAppExit") {
-                    beforeEach {
-                        self.userDefaults.set(AutoLockSetting.OnAppExit.rawValue, forKey: SettingKey.autoLockTime.rawValue)
-                        self.dispatcher.registerStub.onNext(LifecycleAction.background)
-                    }
-
-                    it("locks app") {
-                        expect(self.dataStoreActionHandler.action).to(equal(DataStoreAction.lock))
-                        expect(self.userDefaults.value(forKey: SettingKey.autoLockTimerDate.rawValue)).to(beNil())
-                    }
-                }
-
                 describe("with auto lock setting on never") {
                     beforeEach {
                         self.userDefaults.removeObject(forKey: SettingKey.autoLockTimerDate.rawValue)
@@ -118,13 +106,6 @@ class AutoLockStoreSpec: QuickSpec {
                         expect(self.subject.timer?.isValid).to(beFalsy())
                         expect(self.userDefaults.value(forKey: SettingKey.autoLockTimerDate.rawValue)).to(beNil())
                     }
-
-                    it("doesn't set timer for AutoLockSetting.OnAppExit") {
-                        self.userDefaults.set(AutoLockSetting.OnAppExit.rawValue, forKey: SettingKey.autoLockTime.rawValue)
-                        self.dataStore.lockedStub.onNext(false)
-                        expect(self.subject.timer?.isValid).to(beFalsy())
-                        expect(self.userDefaults.value(forKey: SettingKey.autoLockTimerDate.rawValue)).to(beNil())
-                    }
                 }
 
                 describe("to lock") {
@@ -153,18 +134,6 @@ class AutoLockStoreSpec: QuickSpec {
                         beforeEach {
                             self.userDefaults.set(AutoLockSetting.Never.rawValue, forKey: SettingKey.autoLockTime.rawValue)
                             self.dispatcher.registerStub.onNext(SettingAction.autoLockTime(timeout: .Never))
-                        }
-
-                        it("stops the timer") {
-                            expect(self.subject.timer?.isValid).to(beFalse())
-                            expect(self.userDefaults.value(forKey: SettingKey.autoLockTimerDate.rawValue)).to(beNil())
-                        }
-                    }
-
-                    describe("to OnAppExit") {
-                        beforeEach {
-                            self.userDefaults.set(AutoLockSetting.OnAppExit.rawValue, forKey: SettingKey.autoLockTime.rawValue)
-                            self.dispatcher.registerStub.onNext(SettingAction.autoLockTime(timeout: .OnAppExit))
                         }
 
                         it("stops the timer") {

--- a/lockbox-iosTests/ItemListPresenterSpec.swift
+++ b/lockbox-iosTests/ItemListPresenterSpec.swift
@@ -264,7 +264,7 @@ class ItemListPresenterSpec: QuickSpec {
                             }
                         }
                     }
-      
+
                     describe("when the datastore is preparing") {
                         beforeEach {
                             self.dataStore.syncStateStub.onNext(SyncState.NotSyncable)

--- a/lockbox-iosTests/RootPresenterSpec.swift
+++ b/lockbox-iosTests/RootPresenterSpec.swift
@@ -980,13 +980,6 @@ class RootPresenterSpec: QuickSpec {
                         beforeEach {
                             self.biometryManager.deviceAuthAvailableStub = true
                         }
-                        describe(".OnAppExit") {
-                            it("sets the visual lock") {
-                                UserDefaults.standard.set(AutoLockSetting.OnAppExit.rawValue, forKey: SettingKey.autoLockTime.rawValue)
-                                _ = self.getPresenter()
-                                expect(self.dataStoreActionHandler.action).to(equal(DataStoreAction.lock))
-                            }
-                        }
 
                         describe(".Never") {
                             it("unlocks the visual lock") {
@@ -1018,14 +1011,6 @@ class RootPresenterSpec: QuickSpec {
                     describe("when device authentication is not available") {
                         beforeEach {
                             self.biometryManager.deviceAuthAvailableStub = false
-                        }
-
-                        describe(".OnAppExit") {
-                            it("sets the visual lock") {
-                                UserDefaults.standard.set(AutoLockSetting.OnAppExit.rawValue, forKey: SettingKey.autoLockTime.rawValue)
-                                _ = self.getPresenter()
-                                expect(self.dataStoreActionHandler.action).to(beNil())
-                            }
                         }
 
                         describe(".Never") {

--- a/lockbox-iosTests/UserDefaults+Spec.swift
+++ b/lockbox-iosTests/UserDefaults+Spec.swift
@@ -28,9 +28,9 @@ class UserDefaultSpec: QuickSpec {
             }
 
             it("pushes new values for the SettingKey to observers") {
-                UserDefaults.standard.set(AutoLockSetting.OnAppExit.rawValue, forKey: SettingKey.autoLockTime.rawValue)
+                UserDefaults.standard.set(AutoLockSetting.OneHour.rawValue, forKey: SettingKey.autoLockTime.rawValue)
 
-                expect(autoLockSettingObserver.events.last!.value.element).to(equal(AutoLockSetting.OnAppExit))
+                expect(autoLockSettingObserver.events.last!.value.element).to(equal(AutoLockSetting.OneHour))
             }
 
             it("pushes the default value when a meaningless autolock time is set") {


### PR DESCRIPTION
Fixes #456

@sashei sorry for my ignorance: is this `lifecycleAction` in `AutoLockStore.swift` still needed now?

https://github.com/mozilla-lockbox/lockbox-ios/compare/456-remove-on-app-exit?expand=1#diff-983f28423e9d2c3226bc33cfdb2ce20cR66