### PR TITLE
488-xcuitest-kill-sims-before-tests

### DIFF
--- a/Lockbox.xcodeproj/xcshareddata/xcschemes/lockbox.xcscheme
+++ b/Lockbox.xcodeproj/xcshareddata/xcschemes/lockbox.xcscheme
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
    LastUpgradeVersion = "0930"
-   version = "1.7">
+   version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
       buildImplicitDependencies = "YES">
@@ -27,25 +27,6 @@
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES">
-      <PreActions>
-         <ExecutionAction
-            ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
-            <ActionContent
-               title = "Run Script"
-               scriptText = "xcrun simctl shutdown all&#10;xcrun simctl erase all"
-               shellToInvoke = "/bin/sh">
-               <EnvironmentBuildable>
-                  <BuildableReference
-                     BuildableIdentifier = "primary"
-                     BlueprintIdentifier = "7D5DF8721F87F2600039B23E"
-                     BuildableName = "Firefox Lockbox.app"
-                     BlueprintName = "Firefox Lockbox"
-                     ReferencedContainer = "container:Lockbox.xcodeproj">
-                  </BuildableReference>
-               </EnvironmentBuildable>
-            </ActionContent>
-         </ExecutionAction>
-      </PreActions>
       <Testables>
          <TestableReference
             skipped = "NO">

--- a/Lockbox.xcodeproj/xcshareddata/xcschemes/lockbox.xcscheme
+++ b/Lockbox.xcodeproj/xcshareddata/xcschemes/lockbox.xcscheme
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
    LastUpgradeVersion = "0930"
-   version = "1.3">
+   version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"
       buildImplicitDependencies = "YES">
@@ -27,6 +27,25 @@
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES">
+      <PreActions>
+         <ExecutionAction
+            ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
+            <ActionContent
+               title = "Run Script"
+               scriptText = "xcrun simctl shutdown all&#10;xcrun simctl erase all"
+               shellToInvoke = "/bin/sh">
+               <EnvironmentBuildable>
+                  <BuildableReference
+                     BuildableIdentifier = "primary"
+                     BlueprintIdentifier = "7D5DF8721F87F2600039B23E"
+                     BuildableName = "Firefox Lockbox.app"
+                     BlueprintName = "Firefox Lockbox"
+                     ReferencedContainer = "container:Lockbox.xcodeproj">
+                  </BuildableReference>
+               </EnvironmentBuildable>
+            </ActionContent>
+         </ExecutionAction>
+      </PreActions>
       <Testables>
          <TestableReference
             skipped = "NO">

--- a/Lockbox.xcodeproj/xcshareddata/xcschemes/uispecs.xcscheme
+++ b/Lockbox.xcodeproj/xcshareddata/xcschemes/uispecs.xcscheme
@@ -27,6 +27,16 @@
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES">
+      <PreActions>
+         <ExecutionAction
+            ActionType = "Xcode.IDEStandardExecutionActionsCore.ExecutionActionType.ShellScriptAction">
+            <ActionContent
+               title = "Run Script"
+               scriptText = "xcrun simctl shutdown all&#10;xcrun simctl erase all"
+               shellToInvoke = "/bin/bash">
+            </ActionContent>
+         </ExecutionAction>
+      </PreActions>
       <Testables>
          <TestableReference
             skipped = "NO">


### PR DESCRIPTION
Resolves #488 

This PR adds a pre-test condition to shut down all sims and erase them so we are sure that start from a clean state. The con is that it takes a little bit longer to launch the test since the sim has to start everytime the tests (or one test) is launched.