### PR TITLE
un-hide the nav bar on FxA web view

### DIFF
--- a/lockbox-ios/View/FxAView.swift
+++ b/lockbox-ios/View/FxAView.swift
@@ -34,6 +34,11 @@ class FxAView: UIViewController, FxAViewProtocol, WKNavigationDelegate {
         self.presenter?.onViewReady()
     }
 
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        self.navigationController?.setNavigationBarHidden(false, animated: false)
+    }
+
     func loadRequest(_ urlRequest: URLRequest) {
         self.webView.load(urlRequest)
     }


### PR DESCRIPTION
fixes #505 

Sorry I was messing with both the Welcome and FxA views and forgot to look back at FxA. 😔 

![2018-06-26 15_22_50](https://user-images.githubusercontent.com/49511/41940697-e35e129c-7956-11e8-95f5-697e502dfb49.gif)
