### PR TITLE
Make sure nav bar styles applied correctly all the time but still doesn't break iPhone SE layout

### DIFF
--- a/lockbox-ios/View/ItemListView.swift
+++ b/lockbox-ios/View/ItemListView.swift
@@ -71,6 +71,7 @@ class ItemListView: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         self.view.backgroundColor = Constant.color.viewBackground
+        self.setNeedsStatusBarAppearanceUpdate()
         self.setupRefresh()
         self.styleTableViewBackground()
         self.styleNavigationBar()


### PR DESCRIPTION
Fixes #509 

There _is_ a nav from the Welcome view, kinda... it has to do with popping views on stacks and stuff I guess?

This reverts commit 0fde306e5f82ead4b31b53c7a1a5a6e33258aed7 and adds code comment explaining why to keep it so people like me don't accidentally do it again.

The nav bar results should be:

- Welcome view, not signed in = has black on light gray text
- Welcome view, not signed in, Learn more = does not show a duplicate nav bar, does not break iPhone SE layout, has white text on blue 
- Welcome view, not signed in, Get Started = shows nav bar, has white text on blue
- Orientation view = has black text on white
- List view, first run = has white text on blue
- List view, after lock/unlock = has white text on blue

## Before

![img_3274](https://user-images.githubusercontent.com/49511/41982463-b49a8d7c-79e8-11e8-8b1a-d41a5dc2b927.png)

## After

<img width="252" alt="screen shot 2018-06-27 at 9 21 58 am" src="https://user-images.githubusercontent.com/49511/41983667-0ecd6e7e-79ec-11e8-8fc4-311a12709650.png">

<img width="252" alt="screen shot 2018-06-27 at 9 22 12 am" src="https://user-images.githubusercontent.com/49511/41983673-1291f3a4-79ec-11e8-92aa-fec8ce3c51ac.png">

<img width="252" alt="screen shot 2018-06-27 at 9 26 09 am" src="https://user-images.githubusercontent.com/49511/41983714-250e11d4-79ec-11e8-92c7-cfbc0992ef12.png">
