### PR TITLE
Fix a label width so password label doesn't overlap reveal icon

### DIFF
--- a/lockbox-ios/View/ItemDetailView.swift
+++ b/lockbox-ios/View/ItemDetailView.swift
@@ -142,6 +142,7 @@ extension ItemDetailView: UIGestureRecognizerDelegate {
 
                     if cellConfiguration.password {
                         cell.valueLabel.font = UIFont(name: "Menlo-Regular", size: 16)
+                        cell.valueLabel.preferredMaxLayoutWidth = 250
 
                         if let presenter = self.presenter {
                             cell.revealButton.rx.tap


### PR DESCRIPTION
Fixes #515 

What do you think of this approach @sashei?

It's a bit simplistic and doesn't really allow for a fluid layout. But seems to fit OK on both iPhone SE (small) and iPhone X and at dynamic (bigger) font sizes.

<img width="252" alt="screen shot 2018-06-27 at 2 30 19 pm" src="https://user-images.githubusercontent.com/49511/41998125-39e7338a-7a17-11e8-8059-f5823610ea55.png">
<img width="252" alt="screen shot 2018-06-27 at 2 32 09 pm" src="https://user-images.githubusercontent.com/49511/41998126-39f9fa10-7a17-11e8-90d0-08b9938b0e40.png">
<img width="273" alt="screen shot 2018-06-27 at 2 33 02 pm" src="https://user-images.githubusercontent.com/49511/41998127-3a12057e-7a17-11e8-9ad2-35f19e5fac40.png">
