### PR TITLE
480-verify-testing-account-while-testing

### DIFF
--- a/LockboxXCUITests/LockboxXCUITests.swift
+++ b/LockboxXCUITests/LockboxXCUITests.swift
@@ -7,7 +7,91 @@ import XCTest
 let emailTestAccountLogins = "test-b62feb2ed6@restmail.net"
 let passwordTestAccountLogins = "FRCuQaPm"
 
+var uid: String!
+var code: String!
+
+let firstEntryEmail = "iosmztest@gmail.com"
+
+let getEndPoint = "http://restmail.net/mail/test-b62feb2ed6"
+let postEndPoint = "https://api.accounts.firefox.com/v1/recovery_email/verify_code"
+let deleteEndPoint = "http://restmail.net/mail/test-b62feb2ed6@restmail.net"
+
 class LockboxXCUITests: BaseTestCase {
+
+    override func setUp() {
+        // First Delete the inbox
+        let restUrl = URL(string: deleteEndPoint)
+        var request = URLRequest(url: restUrl!)
+        request.httpMethod = "DELETE"
+
+        let task = URLSession.shared.dataTask(with: request) { data, response, error in
+            print("Delete")
+        }
+        task.resume()
+        super.setUp()
+    }
+
+    private func completeVerification(uid: String, code: String, done: @escaping () -> ()) {
+        // POST to EndPoint api.accounts.firefox.com/v1/recovery_email/verify_code
+        let restUrl = URL(string: postEndPoint)
+        var request = URLRequest(url: restUrl!)
+        request.setValue("application/json; charset=UTF-8", forHTTPHeaderField: "Content-Type")
+
+        request.httpMethod = "POST"
+
+        let jsonObject: [String: Any] = ["uid": uid, "code":code]
+        let data = try! JSONSerialization.data(withJSONObject: jsonObject, options: JSONSerialization.WritingOptions.prettyPrinted)
+        let json = NSString(data: data, encoding: String.Encoding.utf8.rawValue)
+        if let json = json {
+            print("json \(json)")
+        }
+        let jsonData = json?.data(using: String.Encoding.utf8.rawValue)
+
+        request.httpBody = jsonData
+        print("json \(jsonData!)")
+        let task = URLSession.shared.dataTask(with: request) { data, response, error in
+            if let error = error {
+                print("error:", error)
+                return
+            }
+            done()
+        }
+        task.resume()
+    }
+
+    private func verifyAccount(done: @escaping () -> ()) {
+        // GET to EndPoint/mail/test-9876@restmail.net
+        let restUrl = URL(string: getEndPoint)
+        var request = URLRequest(url: restUrl!)
+        request.httpMethod = "GET"
+
+        let task = URLSession.shared.dataTask(with: request) { data, response, error in
+            if(error != nil) {
+                print("Error: \(error ?? "Get Error" as! Error)")
+            }
+            let responseString = String(data: data!, encoding: .utf8)
+            print("responseString = \(String(describing: responseString))")
+
+            let regexpUid = "(uid=[a-z0-9]{0,32}$?)"
+            let regexCode = "(code=[a-z0-9]{0,32}$?)"
+            if let rangeUid = responseString?.range(of:regexpUid, options: .regularExpression) {
+                uid = (responseString?.substring(with:rangeUid))!
+            }
+
+            if let rangeCode = responseString?.range(of:regexCode, options: .regularExpression) {
+                code = (responseString?.substring(with:rangeCode))!
+            }
+
+            let finalCodeIndex = code.index(code.endIndex, offsetBy: -32)
+            let codeNumber = code[finalCodeIndex...]
+            let finalUidIndex = uid.index(uid.endIndex, offsetBy: -32)
+            let uidNumber = uid[finalUidIndex...]
+            self.completeVerification(uid: String(uidNumber), code: String(codeNumber)) {
+                done()
+            }
+        }
+        task.resume()
+    }
 
     func test1LoginWithSavedLogins() {
         snapshot("01Welcome" + CONTENT_SIZE)
@@ -45,7 +129,6 @@ class LockboxXCUITests: BaseTestCase {
         navigator.performAction(Action.FxALogInSuccessfully)
 
         // App should start showing the main page
-        // Instead of waiting we could pull down to refresh to force the logins appear and so the buttons are available
         waitforExistence(app.buttons["finish.button"])
         app.buttons["finish.button"].tap()
         sleep(8)
@@ -59,27 +142,25 @@ class LockboxXCUITests: BaseTestCase {
         XCTAssertTrue(app.navigationBars.buttons["Settings"].exists)
         snapshot("02EntryList" + CONTENT_SIZE)
 
-        // Go to Settings to disable the AutoLock
-        // This is a temporary workaround needed to run other tests after this one until defining a tearDown
         sleep(5)
-        navigator.goto(Screen.SettingsMenu)
-        waitforExistence(app.navigationBars["Settings"])
-        navigator.goto(Screen.AutolockSettingsMenu)
-
-        app.cells.staticTexts["Never"].tap()
-        // Go back to Lockbox main page view
-        navigator.goto(Screen.LockboxMainPage)
-        waitforExistence(app.buttons["sorting.button"])
-        // Just to check that the logins are shown, the table should have more than the cell for search
-        XCTAssertNotEqual(app.tables.cells.count, 1)
-        XCTAssertTrue(app.tables.cells.staticTexts["iosmztest@gmail.com"].exists)
-
-        // Verify that going to a saved login shows the correct options
-        app.tables.cells.staticTexts["iosmztest@gmail.com"].tap()
-        XCTAssertTrue(app.tables.cells.staticTexts["Web Address"].exists)
-        XCTAssertTrue(app.tables.cells.staticTexts["Username"].exists)
-        XCTAssertTrue(app.tables.cells.staticTexts["iosmztest@gmail.com"].exists)
-        XCTAssertTrue(app.tables.cells.staticTexts["Password"].exists)
+        // Check if the account is verified and if not, verify it
+        if (app.staticTexts["Confirm your account."].exists) {
+            let group = DispatchGroup()
+            group.enter()
+            DispatchQueue.global(qos: .userInitiated).async {
+                self.verifyAccount() {
+                    sleep(5)
+                    self.waitforExistence(self.app.staticTexts["No entries found."])
+                    group.leave()
+                }
+            }
+            group.wait()
+        } else {
+            // Account is still verified, check that entries are shown
+            waitforExistence(app.tables.cells.staticTexts[firstEntryEmail])
+            XCTAssertNotEqual(app.tables.cells.count, 1)
+            XCTAssertTrue(app.tables.cells.staticTexts[firstEntryEmail].exists)
+        }
     }
 
     func test2SettingsAccountUI() {
@@ -112,12 +193,15 @@ class LockboxXCUITests: BaseTestCase {
         waitforExistence(app.navigationBars["Firefox Lockbox"])
         let buttonLabelChanged = app.buttons["sorting.button"].label
         XCTAssertEqual(buttonLabelChanged, "Select options for sorting your list of entries (currently Recent)")
+        let firstCellRecent = app.tables.cells.element(boundBy: 1).staticTexts.element(boundBy: 0).label
+        XCTAssertEqual(firstCellRecent, "wopr.norad.org")
         navigator.goto(Screen.SortEntriesMenu)
         navigator.performAction(Action.SelectAlphabeticalOrder)
         let buttonLabelInitally = app.buttons["sorting.button"].label
         waitforExistence(app.navigationBars["Firefox Lockbox"])
         XCTAssertEqual(buttonLabelInitally, "Select options for sorting your list of entries (currently A-Z)")
-        // Pending to create more entries and check that the order is actually changed
+        let firstCellAlphabetically = app.tables.cells.element(boundBy: 1).staticTexts.element(boundBy: 0).label
+        XCTAssertEqual(firstCellAlphabetically, "accounts.google.com")
     }
 
     func test5SettingDisconnectAccount() {
@@ -152,7 +236,30 @@ class LockboxXCUITests: BaseTestCase {
         XCTAssertEqual(app.switches["sendUsageData.switch"].value as? String, "1")
     }
 
-    func test7LockNowUnlock() {
+    func test7EntryDetails() {
+        navigator.goto(Screen.LockboxMainPage)
+        waitforExistence(app.tables.cells.staticTexts["iosmztest@gmail.com"])
+        app.tables.cells.staticTexts["iosmztest@gmail.com"].tap()
+        XCTAssertTrue(app.tables.cells.staticTexts["Web Address"].exists)
+        XCTAssertTrue(app.tables.cells.staticTexts["Username"].exists)
+        XCTAssertTrue(app.tables.cells.staticTexts["iosmztest@gmail.com"].exists)
+        XCTAssertTrue(app.tables.cells.staticTexts["Password"].exists)
+    }
+
+    func test8ChangeDefaultAutolock() {
+        navigator.goto(Screen.SettingsMenu)
+        waitforExistence(app.navigationBars["Settings"])
+        navigator.goto(Screen.AutolockSettingsMenu)
+
+        app.cells.staticTexts["Never"].tap()
+        navigator.goto(Screen.LockboxMainPage)
+        // Send app to background and launch it
+        XCUIDevice.shared.press(.home)
+        app.activate()
+        waitforExistence(app.tables.cells.staticTexts["iosmztest@gmail.com"])
+    }
+
+    func test9LockNowUnlock() {
         navigator.goto(Screen.LockboxMainPage)
         navigator.performAction(Action.LockNow)
         waitforExistence(app.buttons["unlock"])


### PR DESCRIPTION
Fixes #480 and the issues when the testing account needs to be verified by going to the email.
Although it has not been necessary to re-verify the account for some time, better to have a solution on testing time...

The way the verification is done is with a POST request. First we use a DELETE request to be sure we start with an empty inbox, then with GET we retrieve the necessary info to finally POST the uid and verification code so that the account is verified again.

Also I have split the first test adding two new for same checks and improve the test that checks the sort of the entries, the order is modified and now we check that the entries actually change the position

Depends on #522 