### PR TITLE
Pause autolock while the user is on a webpage.

### DIFF
--- a/lockbox-iosTests/AutoLockStoreSpec.swift
+++ b/lockbox-iosTests/AutoLockStoreSpec.swift
@@ -156,6 +156,17 @@ class AutoLockStoreSpec: QuickSpec {
                     }
                 }
 
+                describe("autolock pauses on going to an FAQ or feedback page") {
+                    beforeEach {
+                        let action = ExternalWebsiteRouteAction(urlString: "https://example.com", title: "Feedback form", returnRoute: SettingRouteAction.list)
+                        self.dispatcher.dispatch(action: action)
+                    }
+                    it("resets the timer, but does not clear the fireDate") {
+                        let newFireDate = self.userDefaults.double(forKey: SettingKey.autoLockTimerDate.rawValue)
+                        expect(newFireDate).to(equal(fireDate))
+                    }
+                }
+
                 describe("miscellaneous actions") {
                     sharedExamples(AutoLockStoreSpecSharedExample.TimerReset.rawValue) { context in
                         it("resets the timer") {


### PR DESCRIPTION
Fixes #534.

This PR adds a `paused` property to the `AutoLockStore`.

The auto-lock timer is paused when the user goes to webpage. 

If the timer has already expired when the user closes the page, then the app is locked.

Otherwise, the timer is reset as is normal. 

This allows the user to spend as long as they want on the FAQ or feedback page, without playing whackamole catching events out of a webpage, or compromising the security of the app — sample attack: pausing the timer by going to the FAQ page, then quickly reseting the autolock time to `Never`.