### PR TITLE
Add version parameter to feedback survey URL

### DIFF
--- a/lockbox-ios/Common/Resources/Constants.swift
+++ b/lockbox-ios/Common/Resources/Constants.swift
@@ -12,7 +12,7 @@ struct Constant {
         static let redirectURI = "https://mozilla-lockbox.github.io/fxa/ios-redirect.html"
         static let faqURL = "https://lockbox.firefox.com/faq.html"
         static let privacyURL = "https://lockbox.firefox.com/privacy.html"
-        static let provideFeedbackURL = "https://qsurvey.mozilla.com/s3/Lockbox-Input?ver=" + appVersion!
+        static let provideFeedbackURL = "https://qsurvey.mozilla.com/s3/Lockbox-Input?ver=\(appVersion ?? "1.1")"
         static let useLockboxFAQ = faqURL + "#how-do-i-use-firefox-lockbox"
         static let enableSyncFAQ = faqURL + "#how-do-i-enable-sync-on-firefox"
         static let editExistingEntriesFAQ = faqURL + "#how-do-i-edit-existing-entries"

--- a/lockbox-ios/Common/Resources/Constants.swift
+++ b/lockbox-ios/Common/Resources/Constants.swift
@@ -8,10 +8,11 @@ import UIKit
 
 struct Constant {
     struct app {
+        static let appVersion = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String
         static let redirectURI = "https://mozilla-lockbox.github.io/fxa/ios-redirect.html"
         static let faqURL = "https://lockbox.firefox.com/faq.html"
         static let privacyURL = "https://lockbox.firefox.com/privacy.html"
-        static let provideFeedbackURL = "https://qsurvey.mozilla.com/s3/Lockbox-Input"
+        static let provideFeedbackURL = "https://qsurvey.mozilla.com/s3/Lockbox-Input?ver=" + appVersion!
         static let useLockboxFAQ = faqURL + "#how-do-i-use-firefox-lockbox"
         static let enableSyncFAQ = faqURL + "#how-do-i-enable-sync-on-firefox"
         static let editExistingEntriesFAQ = faqURL + "#how-do-i-edit-existing-entries"

--- a/lockbox-ios/Presenter/SettingListPresenter.swift
+++ b/lockbox-ios/Presenter/SettingListPresenter.swift
@@ -149,7 +149,7 @@ extension SettingListPresenter {
         var supportSettingSection = self.staticSupportSettingSection
         supportSettingSection.items.append(usageDataSetting)
 
-        if let appVersion = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String {
+        if let appVersion = Constant.app.appVersion {
             let appVersionSetting = SettingCellConfiguration(text: Constant.string.settingsAppVersion, routeAction: nil)
             appVersionSetting.detailText = appVersion
             supportSettingSection.items.append(appVersionSetting)


### PR DESCRIPTION
Fixes #563 

This sets the feedback survey URL to:
https://qsurvey.mozilla.com/s3/Lockbox-Input?ver=1.1.1 (with the `ver=1.1.1` at the end)

![screen shot 2018-07-17 at 9 38 05 am](https://user-images.githubusercontent.com/49511/42828103-34734586-89a5-11e8-85cb-99952b54c2e0.png)

Also re-purposed a single constant to be used in the settings output. @joeyg does that look OK to you? It still works, so I've got that going for me...

![screen shot 2018-07-17 at 9 40 00 am](https://user-images.githubusercontent.com/49511/42828196-6ab53668-89a5-11e8-9100-384b2111305c.png)

