### PR TITLE
531-XCUITests-more-independent (wip)

### DIFF
--- a/LockboxXCUITests/LockBoxScreenGraph.swift
+++ b/LockboxXCUITests/LockBoxScreenGraph.swift
@@ -155,3 +155,135 @@ func createScreenGraph(for test: XCTestCase, with app: XCUIApplication) -> MMScr
 
     return map
 }
+
+extension BaseTestCase {
+
+    func waitForMainPage() {
+        let app = XCUIApplication()
+        waitforExistence(app.navigationBars["Firefox Lockbox"])
+        waitforExistence(app.tables.cells.staticTexts[firstEntryEmail], timeout: 10)
+    }
+
+    func enterDataAndTapOnSignIn() {
+        waitforExistence(app.webViews.secureTextFields["Password"])
+        userState.fxaUsername = emailTestAccountLogins
+        navigator.performAction(Action.FxATypeEmail)
+        userState.fxaPassword = passwordTestAccountLogins
+        navigator.performAction(Action.FxATypePassword)
+
+        navigator.performAction(Action.FxATapOnSignInButton)
+        waitforExistence(app.buttons["finish.button"])
+        app.buttons["finish.button"].tap()
+        waitForMainPage()
+    }
+
+    func disconnectAccount() {
+        navigator.performAction(Action.DisconnectFirefoxLockbox)
+        waitforExistence(app.buttons["getStarted.button"])
+        app.buttons["getStarted.button"].tap()
+        waitforExistence(app.staticTexts[emailTestAccountLogins])
+        app.webViews.links["Use a different account"].tap()
+        waitforExistence(app.webViews.textFields["Email"], timeout: 10)
+    }
+
+    func logInFxAcc() {
+        navigator.nowAt(Screen.FxASigninScreen)
+        enterDataAndTapOnSignIn()
+        checkIfAccountIsVerified()
+        waitForMainPage()
+    }
+
+    func checkIfAccountIsVerified() {
+        if (app.staticTexts["Confirm your account."].exists) {
+            let group = DispatchGroup()
+            group.enter()
+            DispatchQueue.global(qos: .userInitiated).async { [weak self] in
+                self?.verifyAccount() {
+                    group.leave()
+                }
+            }
+            group.wait()
+            waitforNoExistence(app.staticTexts["Confirm your account."], timeoutValue: 5)
+            waitforExistence(app.tables.cells.staticTexts[firstEntryEmail], timeout: 20)
+        } else {
+            // Account is still verified, check that entries are shown
+            waitforNoExistence(app.staticTexts["Confirm your account."], timeoutValue: 5)
+            waitforExistence(app.tables.cells.staticTexts[firstEntryEmail])
+            XCTAssertNotEqual(app.tables.cells.count, 1)
+            XCTAssertTrue(app.tables.cells.staticTexts[firstEntryEmail].exists)
+        }
+        navigator.nowAt(Screen.LockboxMainPage)
+    }
+
+    func completeVerification(uid: String, code: String, done: @escaping () -> ()) {
+        // POST to EndPoint api.accounts.firefox.com/v1/recovery_email/verify_code
+        let restUrl = URL(string: postEndPoint)
+        var request = URLRequest(url: restUrl!)
+        request.setValue("application/json; charset=UTF-8", forHTTPHeaderField: "Content-Type")
+
+        request.httpMethod = "POST"
+
+        let jsonObject: [String: Any] = ["uid": uid, "code":code]
+        let data = try! JSONSerialization.data(withJSONObject: jsonObject, options: JSONSerialization.WritingOptions.prettyPrinted)
+        let json = NSString(data: data, encoding: String.Encoding.utf8.rawValue)
+        if let json = json {
+            print("json \(json)")
+        }
+        let jsonData = json?.data(using: String.Encoding.utf8.rawValue)
+
+        request.httpBody = jsonData
+        print("json \(jsonData!)")
+        let task = URLSession.shared.dataTask(with: request) { data, response, error in
+            if let error = error {
+                print("error:", error)
+                return
+            }
+            done()
+        }
+        task.resume()
+    }
+
+   func verifyAccount(done: @escaping () -> ()) {
+        // GET to EndPoint/mail/test-9876@restmail.net
+        let restUrl = URL(string: getEndPoint)
+        var request = URLRequest(url: restUrl!)
+        request.httpMethod = "GET"
+
+        let task = URLSession.shared.dataTask(with: request) { data, response, error in
+            if(error != nil) {
+                print("Error: \(error ?? "Get Error" as! Error)")
+            }
+            let responseString = String(data: data!, encoding: .utf8)
+            print("responseString = \(String(describing: responseString))")
+
+            let regexpUid = "(uid=[a-z0-9]{0,32}$?)"
+            let regexCode = "(code=[a-z0-9]{0,32}$?)"
+            if let rangeUid = responseString?.range(of:regexpUid, options: .regularExpression) {
+                uid = String(responseString![rangeUid])
+            }
+
+            if let rangeCode = responseString?.range(of:regexCode, options: .regularExpression) {
+                code = String(responseString![rangeCode])
+            }
+
+            if (code != nil && uid != nil) {
+                let codeNumber = self.getPostValues(value: code)
+                let uidNumber = self.getPostValues(value: uid)
+
+                self.completeVerification(uid: String(uidNumber), code: String(codeNumber)) {
+                    done()
+                }
+            } else {
+                done()
+            }
+        }
+        task.resume()
+    }
+
+    func getPostValues(value: String) -> String {
+        // From the regExp it is necessary to get only the number to add it to a json and send in POST request
+        let finalNumberIndex = value.index(value.endIndex, offsetBy: -32);
+        let numberValue = value[finalNumberIndex...];
+        return String(numberValue)
+    }
+}

--- a/LockboxXCUITests/LockboxXCUITests.swift
+++ b/LockboxXCUITests/LockboxXCUITests.swift
@@ -47,11 +47,13 @@ class LockboxXCUITests: BaseTestCase {
             app.buttons["getStarted.button"].tap()
             waitforExistence(app.webViews.secureTextFields["Password"])
             if (app.staticTexts[emailTestAccountLogins].exists) {
-                app.webViews.links["Use a different account"].tap()
+                navigator.nowAt(Screen.FxASigninScreenSavedUser)
+                navigator.performAction(Action.DisconnectUser)
                 waitforExistence(app.webViews.textFields["Email"], timeout: 10)
                 logInFxAcc()
             } else {
             // Starting like first time
+            navigator.nowAt(Screen.FxASigninScreen)
             logInFxAcc()
             }
         }
@@ -65,9 +67,8 @@ class LockboxXCUITests: BaseTestCase {
             app.buttons["getStarted.button"].tap()
             waitforExistence(app.webViews.secureTextFields["Password"])
             if(app.staticTexts[emailTestAccountLogins].exists) {
-                app.webViews.links["Use a different account"].tap()
-                waitforExistence(app.webViews.textFields["Email"], timeout: 10)
-                navigator.nowAt(Screen.FxASigninScreen)
+                navigator.nowAt(Screen.FxASigninScreenSavedUser)
+                navigator.performAction(Action.DisconnectUser)
             } else {
                 navigator.nowAt(Screen.FxASigninScreen)
             }

--- a/LockboxXCUITests/LockboxXCUITests.swift
+++ b/LockboxXCUITests/LockboxXCUITests.swift
@@ -242,9 +242,11 @@ class LockboxXCUITests: BaseTestCase {
                 }
             }
             group.wait()
+            waitforNoExistence(app.staticTexts["Confirm your account."], timeoutValue: 5)
             waitforExistence(app.tables.cells.staticTexts[firstEntryEmail], timeout: 20)
         } else {
             // Account is still verified, check that entries are shown
+            waitforNoExistence(app.staticTexts["Confirm your account."], timeoutValue: 5)
             waitforExistence(app.tables.cells.staticTexts[firstEntryEmail])
             XCTAssertNotEqual(app.tables.cells.count, 1)
             XCTAssertTrue(app.tables.cells.staticTexts[firstEntryEmail].exists)
@@ -253,9 +255,9 @@ class LockboxXCUITests: BaseTestCase {
 
     func testMainScreen() {
         preTestStatus()
+        checkIfAccountIsVerified()
         // Check how to order the entries
         navigator.nowAt(Screen.LockboxMainPage)
-        sleep(5)
         navigator.performAction(Action.SelectRecentOrder)
         waitforExistence(app.navigationBars["Firefox Lockbox"])
         let buttonLabelChanged = app.buttons["sorting.button"].label
@@ -273,6 +275,7 @@ class LockboxXCUITests: BaseTestCase {
 
     func testSettingsMainPage() {
         preTestStatus()
+        checkIfAccountIsVerified()
         navigator.nowAt(Screen.LockboxMainPage)
 
         // Check the Lock Now button
@@ -302,6 +305,7 @@ class LockboxXCUITests: BaseTestCase {
 
     func testDifferentSettings() {
         preTestStatus()
+        checkIfAccountIsVerified()
         navigator.nowAt(Screen.LockboxMainPage)
 
         // Check the Account Setting
@@ -347,6 +351,7 @@ class LockboxXCUITests: BaseTestCase {
 
     func testEntryDetail() {
         preTestStatus()
+        checkIfAccountIsVerified()
         navigator.nowAt(Screen.LockboxMainPage)
 
         // Check the Entry Detail View and its details

--- a/LockboxXCUITests/LockboxXCUITests.swift
+++ b/LockboxXCUITests/LockboxXCUITests.swift
@@ -121,38 +121,34 @@ class LockboxXCUITests: BaseTestCase {
 
     private func preTestStatus() {
         // App can start with user logged out, user logged out (email saved), user logged in
+        // if user logged in, log out
         if (app.navigationBars["Firefox Lockbox"].exists) {
             disconnectAccount()
             logInAgain()
-        } else if (app.staticTexts[emailTestAccountLogins].exists){
-            app.webViews.links["Use a different account"].tap()
-            waitforExistence(app.webViews.textFields["Email"], timeout: 10)
+        } else if (app.buttons["getStarted.button"].exists) {
+            // User logged out but emal remembered
+            app.buttons["getStarted.button"].tap()
+            waitforExistence(app.webViews.secureTextFields["Password"])
+            if (app.staticTexts[emailTestAccountLogins].exists) {
+                app.webViews.links["Use a different account"].tap()
+                waitforExistence(app.webViews.textFields["Email"], timeout: 10)
+                logInAgain()
+            } else {
+            // Starting like first time
             logInAgain()
-        } else {
-            firstLogin()
+            }
         }
     }
 
     private func logInAgain() {
         navigator.nowAt(Screen.FxASigninScreen)
         enterDataAndTapOnSignIn()
-        sleep(5)
-        checkIfAccountIsVerified()
-        waitForMainPage()
-    }
-
-    private func firstLogin() {
-        navigator.goto(Screen.FxASigninScreen)
-        waitforExistence(app.webViews.secureTextFields["Password"])
-
-        enterDataAndTapOnSignIn()
-        sleep(5)
-        // Check if the account is verified and if not, verify it
         checkIfAccountIsVerified()
         waitForMainPage()
     }
 
     private func enterDataAndTapOnSignIn() {
+        waitforExistence(app.webViews.secureTextFields["Password"])
         userState.fxaUsername = emailTestAccountLogins
         navigator.performAction(Action.FxATypeEmail)
         userState.fxaPassword = passwordTestAccountLogins
@@ -161,6 +157,7 @@ class LockboxXCUITests: BaseTestCase {
         navigator.performAction(Action.FxATapOnSignInButton)
         waitforExistence(app.buttons["finish.button"])
         app.buttons["finish.button"].tap()
+        waitForMainPage()
     }
 
     private func waitForMainPage() {
@@ -172,12 +169,16 @@ class LockboxXCUITests: BaseTestCase {
         if (app.navigationBars["Firefox Lockbox"].exists) {
             disconnectAccount()
             navigator.nowAt(Screen.FxASigninScreen)
-        } else if (app.staticTexts[emailTestAccountLogins].exists){
-            app.webViews.links["Use a different account"].tap()
-            waitforExistence(app.webViews.textFields["Email"], timeout: 10)
-            navigator.nowAt(Screen.FxASigninScreen)
-        } else {
-            navigator.goto(Screen.FxASigninScreen)
+        } else if (app.buttons["getStarted.button"].exists){
+            app.buttons["getStarted.button"].tap()
+            waitforExistence(app.webViews.secureTextFields["Password"])
+            if(app.staticTexts[emailTestAccountLogins].exists) {
+                app.webViews.links["Use a different account"].tap()
+                waitforExistence(app.webViews.textFields["Email"], timeout: 10)
+                navigator.nowAt(Screen.FxASigninScreen)
+            } else {
+                navigator.nowAt(Screen.FxASigninScreen)
+            }
         }
         snapshot("01Welcome" + CONTENT_SIZE)
         waitforExistence(app.webViews.textFields["Email"])


### PR DESCRIPTION
Resolves #531 

This needs PR #530 before. Once that one lands, this needs to be rebased and modified according to it to add the improvements, changes and tests introduced in that PR.

The idea is to make tests independent from the previous one. Now it would not matter the order when running the tests. 
There are less tests but each one does the necessary checks so that in the end, we have the same coverage for the features/menus and so.






 