### PR TITLE
Position label relative to the spinner

### DIFF
--- a/lockbox-ios/Storyboard/Base.lproj/SpinnerAlert.xib
+++ b/lockbox-ios/Storyboard/Base.lproj/SpinnerAlert.xib
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14113" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="14109" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
@@ -32,7 +32,7 @@
             <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.90000000000000002" colorSpace="custom" customColorSpace="displayP3"/>
             <constraints>
                 <constraint firstItem="1Mj-QY-mDP" firstAttribute="centerX" secondItem="iN0-l3-epB" secondAttribute="centerX" id="2DQ-hn-m9y"/>
-                <constraint firstItem="1Mj-QY-mDP" firstAttribute="top" secondItem="iN0-l3-epB" secondAttribute="top" constant="67" id="IHO-QR-1Rv"/>
+                <constraint firstItem="1Mj-QY-mDP" firstAttribute="top" secondItem="mO2-mg-hqg" secondAttribute="bottom" constant="10" id="IHO-QR-1Rv"/>
                 <constraint firstAttribute="bottom" secondItem="1Mj-QY-mDP" secondAttribute="bottom" constant="20" id="KXN-re-ANZ"/>
                 <constraint firstItem="mO2-mg-hqg" firstAttribute="top" secondItem="iN0-l3-epB" secondAttribute="topMargin" constant="20" id="L9a-gx-P6H"/>
                 <constraint firstItem="mO2-mg-hqg" firstAttribute="centerX" secondItem="iN0-l3-epB" secondAttribute="centerX" id="T6z-6q-Gk5"/>


### PR DESCRIPTION
Fixes #570

I am not sure why the view has smaller height on 10.3, but positioning the label relative to the spinner makes it have no margin between on the previous iOS version.

Examples:
iPhone SE (10.3.1) ![se_10 3 1](https://user-images.githubusercontent.com/1129082/43418831-7f565544-943f-11e8-9f3d-37c3b0a36ac1.png)
iPhone SE (11.3) ![se_11 3](https://user-images.githubusercontent.com/1129082/43418832-7f70160a-943f-11e8-8c20-7a92b4832001.png)
