### PR TITLE
Ignore dynamic type settings for navigation bar items

### DIFF
--- a/Lockbox.xcodeproj/project.pbxproj
+++ b/Lockbox.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		22336C7221111087004E7B50 /* OnboardingConfirmationPresenterSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22336C7121111087004E7B50 /* OnboardingConfirmationPresenterSpec.swift */; };
+		224A6C7D212C8C2B008C7A3F /* UIFont+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 224A6C7C212C8C2B008C7A3F /* UIFont+.swift */; };
 		226E3FF02127759C00185D11 /* ExternalLinkStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 226E3FEF2127759C00185D11 /* ExternalLinkStore.swift */; };
 		2C2EC55520ADA85A00AF8C44 /* LockboxXCUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C2EC55420ADA85A00AF8C44 /* LockboxXCUITests.swift */; };
 		2C2EC56020ADAA8100AF8C44 /* MappaMundi.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 2C2EC55F20ADAA8100AF8C44 /* MappaMundi.framework */; };
@@ -225,6 +226,7 @@
 
 /* Begin PBXFileReference section */
 		22336C7121111087004E7B50 /* OnboardingConfirmationPresenterSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingConfirmationPresenterSpec.swift; sourceTree = "<group>"; };
+		224A6C7C212C8C2B008C7A3F /* UIFont+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIFont+.swift"; sourceTree = "<group>"; };
 		226E3FEF2127759C00185D11 /* ExternalLinkStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExternalLinkStore.swift; sourceTree = "<group>"; };
 		2C2EC55220ADA85A00AF8C44 /* LockboxXCUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = LockboxXCUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		2C2EC55420ADA85A00AF8C44 /* LockboxXCUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LockboxXCUITests.swift; sourceTree = "<group>"; };
@@ -623,6 +625,7 @@
 				4C7F3C7C20B3C32A00C4C414 /* UIButton+.swift */,
 				7AA54D3C8D454F79BD580AAF /* UserDefaults+.swift */,
 				D86A307520829B7F00589CA8 /* UIApplication+.swift */,
+				224A6C7C212C8C2B008C7A3F /* UIFont+.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -1133,6 +1136,7 @@
 				7AA54E83D68AA39FB3A895AF /* RootPresenter.swift in Sources */,
 				7AA54B936D967416C7AD4F3C /* Observable+.swift in Sources */,
 				7D6FB87B204F00E2005E23AA /* StatusAlert.swift in Sources */,
+				224A6C7D212C8C2B008C7A3F /* UIFont+.swift in Sources */,
 				D86A307620829B7F00589CA8 /* UIApplication+.swift in Sources */,
 				7AA548BBE384D40397D26E9B /* RootView.swift in Sources */,
 				7D1B22062033C5880098C3A3 /* ItemDetailPresenter.swift in Sources */,

--- a/lockbox-ios/Common/Extensions/UIFont+.swift
+++ b/lockbox-ios/Common/Extensions/UIFont+.swift
@@ -1,0 +1,26 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import UIKit
+
+extension UIFont {
+
+    /** Returns a font to be used for a button in a navigation bar.
+     *
+     * Note: the font does *not* scale for different dynamic type settings.
+     */
+    static var navigationButtonFont: UIFont {
+        return self.preferredFont(forTextStyle: .body,
+                                  compatibleWith: UITraitCollection(preferredContentSizeCategory: .large))
+    }
+
+    /** Returns a font to be used for a title in a navigation bar.
+     *
+     * Note: the font does *not* scale for different dynamic type settings.
+     */
+    static var navigationTitleFont: UIFont {
+        return self.preferredFont(forTextStyle: .headline,
+                                  compatibleWith: UITraitCollection(preferredContentSizeCategory: .large))
+    }
+}

--- a/lockbox-ios/View/AccountSettingView.swift
+++ b/lockbox-ios/View/AccountSettingView.swift
@@ -65,12 +65,12 @@ extension AccountSettingView: UIGestureRecognizerDelegate {
     fileprivate func setupNavBar() {
         self.navigationItem.title = Constant.string.account
         self.navigationController?.navigationBar.titleTextAttributes = [
-            NSAttributedStringKey.foregroundColor: UIColor.white,
-            NSAttributedStringKey.font: UIFont.preferredFont(forTextStyle: .headline)
+            .foregroundColor: UIColor.white,
+            .font: UIFont.navigationTitleFont
         ]
         self.navigationController?.navigationBar.accessibilityIdentifier = "accountSetting.navigationBar"
         let leftButton = UIButton(title: Constant.string.settingsTitle, imageName: "back")
-        leftButton.titleLabel?.font = UIFont.preferredFont(forTextStyle: .body)
+        leftButton.titleLabel?.font = .navigationButtonFont
         self.navigationItem.leftBarButtonItem = UIBarButtonItem(customView: leftButton)
 
         if let presenter = self.presenter {

--- a/lockbox-ios/View/AutoLockSettingsView.swift
+++ b/lockbox-ios/View/AutoLockSettingsView.swift
@@ -98,8 +98,8 @@ extension AutoLockSettingView: UIGestureRecognizerDelegate {
     private func setupNavbar() {
         self.navigationItem.title = Constant.string.settingsAutoLock
         self.navigationController?.navigationBar.titleTextAttributes = [
-            NSAttributedStringKey.foregroundColor: UIColor.white,
-            NSAttributedStringKey.font: UIFont.systemFont(ofSize: 18, weight: .semibold)
+            .foregroundColor: UIColor.white,
+            .font: UIFont.navigationTitleFont
         ]
 
         let leftButton = UIButton(title: Constant.string.settingsTitle, imageName: "back")

--- a/lockbox-ios/View/FxAView.swift
+++ b/lockbox-ios/View/FxAView.swift
@@ -72,7 +72,7 @@ extension FxAView: WKNavigationDelegate {
 extension FxAView: UIGestureRecognizerDelegate {
     fileprivate func setupNavBar() {
         let leftButton = UIButton(title: Constant.string.close, imageName: nil)
-        leftButton.titleLabel?.font = UIFont.preferredFont(forTextStyle: .body)
+        leftButton.titleLabel?.font = .navigationButtonFont
         self.navigationItem.leftBarButtonItem = UIBarButtonItem(customView: leftButton)
 
         if #available(iOS 11.0, *) {

--- a/lockbox-ios/View/ItemDetailView.swift
+++ b/lockbox-ios/View/ItemDetailView.swift
@@ -98,7 +98,7 @@ extension ItemDetailView: ItemDetailViewProtocol {
 extension ItemDetailView: UIGestureRecognizerDelegate {
     fileprivate func setupNavigation() {
         let leftButton = UIButton(title: Constant.string.back, imageName: "back")
-        leftButton.titleLabel?.font = UIFont.preferredFont(forTextStyle: .body)
+        leftButton.titleLabel?.font = .navigationButtonFont
         self.navigationItem.leftBarButtonItem = UIBarButtonItem(customView: leftButton)
 
         if #available(iOS 11.0, *) {
@@ -107,8 +107,8 @@ extension ItemDetailView: UIGestureRecognizerDelegate {
 
         self.navigationController?.navigationBar.tintColor = UIColor.white
         self.navigationController?.navigationBar.titleTextAttributes = [
-            NSAttributedStringKey.foregroundColor: UIColor.white,
-            NSAttributedStringKey.font: UIFont.systemFont(ofSize: 18, weight: .semibold)
+            .foregroundColor: UIColor.white,
+            .font: UIFont.navigationTitleFont
         ]
 
         if let presenter = self.presenter {

--- a/lockbox-ios/View/ItemListView.swift
+++ b/lockbox-ios/View/ItemListView.swift
@@ -248,8 +248,8 @@ extension ItemListView {
         self.navigationController?.navigationBar.tintColor = UIColor.white
         self.navigationController?.navigationBar.accessibilityIdentifier = "firefoxLockbox.navigationBar"
         self.navigationController?.navigationBar.titleTextAttributes = [
-            NSAttributedStringKey.foregroundColor: UIColor.white,
-            NSAttributedStringKey.font: UIFont.preferredFont(forTextStyle: .headline)
+            .foregroundColor: UIColor.white,
+            .font: UIFont.navigationTitleFont
         ]
 
         if #available(iOS 11.0, *) {
@@ -276,10 +276,6 @@ extension ItemListView {
     private var prefButton: UIButton {
         let button = UIButton()
         button.accessibilityIdentifier = "settings.button"
-        if #available(iOS 11.0, *) {
-            button.adjustsImageSizeForAccessibilityContentSizeCategory = true
-        }
-
         let prefImage = UIImage(named: "preferences")?.withRenderingMode(.alwaysTemplate)
         button.accessibilityLabel = Constant.string.settingsAccessibilityID
         let tintedPrefImage = prefImage?.tinted(UIColor(white: 1.0, alpha: 0.6))
@@ -295,13 +291,10 @@ extension ItemListView {
 
     private var sortingButton: UIButton {
         let button = UIButton(title: Constant.string.aToZ, imageName: "down-caret")
-        button.titleLabel?.font = UIFont.preferredFont(forTextStyle: .body)
+        button.titleLabel?.font = .navigationButtonFont
         // custom width constraint so "Recent" fits on small iPhone SE screen
         button.accessibilityIdentifier = "sorting.button"
         button.translatesAutoresizingMaskIntoConstraints = false
-        if #available(iOS 11.0, *) {
-            button.adjustsImageSizeForAccessibilityContentSizeCategory = true
-        }
         button.addConstraint(NSLayoutConstraint(
                 item: button,
                 attribute: .width,

--- a/lockbox-ios/View/PreferredBrowserSettingView.swift
+++ b/lockbox-ios/View/PreferredBrowserSettingView.swift
@@ -101,12 +101,12 @@ extension PreferredBrowserSettingView: UIGestureRecognizerDelegate {
     private func setupNavbar() {
         self.navigationItem.title = Constant.string.settingsBrowser
         self.navigationController?.navigationBar.titleTextAttributes = [
-            NSAttributedStringKey.foregroundColor: UIColor.white,
-            NSAttributedStringKey.font: UIFont.preferredFont(forTextStyle: .headline)
+            .foregroundColor: UIColor.white,
+            .font: UIFont.navigationTitleFont
         ]
         self.navigationController?.navigationBar.accessibilityIdentifier = "openWebSitesIn.navigationBar"
         let leftButton = UIButton(title: Constant.string.settingsTitle, imageName: "back")
-        leftButton.titleLabel?.font = UIFont.preferredFont(forTextStyle: .body)
+        leftButton.titleLabel?.font = .navigationButtonFont
         self.navigationItem.leftBarButtonItem = UIBarButtonItem(customView: leftButton)
 
         if let presenter = self.presenter {

--- a/lockbox-ios/View/SettingListView.swift
+++ b/lockbox-ios/View/SettingListView.swift
@@ -115,8 +115,8 @@ extension SettingListView {
         self.navigationItem.title = Constant.string.settingsTitle
         self.navigationController?.navigationBar.tintColor = UIColor.white
         self.navigationController?.navigationBar.titleTextAttributes = [
-            NSAttributedStringKey.foregroundColor: UIColor.white,
-            NSAttributedStringKey.font: UIFont.preferredFont(forTextStyle: .headline)
+            .foregroundColor: UIColor.white,
+            .font: UIFont.navigationTitleFont
         ]
         self.navigationController?.navigationBar.accessibilityIdentifier = "settings.navigationBar"
 
@@ -129,8 +129,8 @@ extension SettingListView {
                 target: nil,
                 action: nil)
         navigationItem.rightBarButtonItem?.setTitleTextAttributes([
-            NSAttributedStringKey.foregroundColor: UIColor.white,
-            NSAttributedStringKey.font: UIFont.preferredFont(forTextStyle: .body)
+            .foregroundColor: UIColor.white,
+            .font: UIFont.navigationButtonFont
         ], for: .normal)
 
         if let presenter = presenter {

--- a/lockbox-ios/View/StaticURLWebView.swift
+++ b/lockbox-ios/View/StaticURLWebView.swift
@@ -49,8 +49,8 @@ class StaticURLWebView: UIViewController {
         self.navigationItem.title = self.navTitle
         self.navigationController?.navigationBar.tintColor = UIColor.white
         self.navigationController?.navigationBar.titleTextAttributes = [
-            NSAttributedStringKey.foregroundColor: UIColor.white,
-            NSAttributedStringKey.font: UIFont.preferredFont(forTextStyle: .headline)
+            .foregroundColor: UIColor.white,
+            .font: UIFont.navigationTitleFont
         ]
 
         if #available(iOS 11.0, *) {
@@ -63,7 +63,7 @@ class StaticURLWebView: UIViewController {
                 target: nil,
                 action: nil)
         self.navigationItem.leftBarButtonItem?.setTitleTextAttributes([
-            NSAttributedStringKey.font: UIFont.preferredFont(forTextStyle: .body)
+            .font: UIFont.navigationButtonFont
         ], for: .normal)
     }
 }


### PR DESCRIPTION
Apple does not scale the navigation items. We should not do that either.

Partially addresses #512.

Connected to #512