### PR TITLE
Add a "Get Support" link to Discourse in setting list

### DIFF
--- a/lockbox-ios/Action/TelemetryAction.swift
+++ b/lockbox-ios/Action/TelemetryAction.swift
@@ -40,6 +40,7 @@ enum TelemetryEventObject: String {
     case settingsItemListSort = "settings_item_list_sort"
     case settingsFaq = "settings_faq"
     case settingsProvideFeedback = "settings_provide_feedback"
+    case settingsGetSupport = "settings_get_support"
     case loginWelcome = "login_welcome"
     case loginFxa = "login_fxa"
     case loginOnboardingConfirmation = "login_onboarding_confirmation"

--- a/lockbox-ios/Common/Resources/Constants.swift
+++ b/lockbox-ios/Common/Resources/Constants.swift
@@ -13,6 +13,7 @@ struct Constant {
         static let faqURL = "https://lockbox.firefox.com/faq.html"
         static let privacyURL = "https://lockbox.firefox.com/privacy.html"
         static let provideFeedbackURL = "https://qsurvey.mozilla.com/s3/Lockbox-Input?ver=\(appVersion ?? "1.1")"
+        static let getSupportURL = "https://discourse.mozilla.org/c/test-pilot/lockbox"
         static let useLockboxFAQ = faqURL + "#how-do-i-use-firefox-lockbox"
         static let enableSyncFAQ = faqURL + "#how-do-i-enable-sync-on-firefox"
         static let editExistingEntriesFAQ = faqURL + "#how-do-i-edit-existing-entries"
@@ -73,6 +74,7 @@ struct Constant {
         static let settingsConfigurationSectionHeader = NSLocalizedString("settings.configuration.header", value: "CONFIGURATION", comment: "Configuration label in settings")
         static let settingsTitle = NSLocalizedString("settings.title", value: "Settings", comment: "Title on settings screen")
         static let settingsProvideFeedback = NSLocalizedString("settings.provideFeedback", value: "Send Feedback", comment: "Send feedback option in settings")
+        static let settingsGetSupport = NSLocalizedString("settings.getSupport", value: "Ask Questions", comment: "Support link to Discourse discussion forum")
         static let faq = NSLocalizedString("settings.faq", value: "FAQ", comment: "FAQ option in settings")
         static let settingsAccount = NSLocalizedString("settings.account", value: "Account", comment: "Account option in settings")
         static let settingsAutoLock = NSLocalizedString("settings.autoLock", value: "Auto Lock", comment: "Auto Lock option in settings")

--- a/lockbox-ios/Presenter/SettingListPresenter.swift
+++ b/lockbox-ios/Presenter/SettingListPresenter.swift
@@ -71,6 +71,13 @@ class SettingListPresenter {
                             returnRoute: SettingRouteAction.list),
                             accessibilityId: "sendFeedbackSettingOption"),
             SettingCellConfiguration(
+                text: Constant.string.settingsGetSupport,
+                routeAction: ExternalWebsiteRouteAction(
+                    urlString: Constant.app.getSupportURL,
+                    title: Constant.string.settingsGetSupport,
+                    returnRoute: SettingRouteAction.list),
+                accessibilityId: "getSupportSettingOption"),
+            SettingCellConfiguration(
                     text: Constant.string.faq,
                     routeAction: ExternalWebsiteRouteAction(
                             urlString: Constant.app.faqURL,


### PR DESCRIPTION
Resolves #637 (still marked as "needs-design")

I took some liberty here and assumed we'd just add a link in the existing Support section and called that link "Ask Questions" (as a placeholder).

To test:

- open app and sign in
- open Settings screen
- observe the link in the "Support" heading
- tap it and it opens a web view with the discourse forum

Screenshots demonstrating this:

<img width="387" alt="screen shot 2018-08-24 at 4 49 37 pm" src="https://user-images.githubusercontent.com/49511/44611326-c0cb3300-a7bd-11e8-8e8c-cfba7ceb5990.png">

<img width="387" alt="screen shot 2018-08-24 at 4 49 53 pm" src="https://user-images.githubusercontent.com/49511/44611328-c294f680-a7bd-11e8-9ee0-4bc22ee40b22.png">


