### PR TITLE
add login and disconnect oauth telemetry events

### DIFF
--- a/lockbox-ios/Action/AccountAction.swift
+++ b/lockbox-ios/Action/AccountAction.swift
@@ -29,3 +29,28 @@ extension AccountAction: Equatable {
         }
     }
 }
+
+extension AccountAction: TelemetryAction {
+    var eventMethod: TelemetryEventMethod {
+        switch self {
+        case .oauthRedirect(let URL):
+            return .signIn
+        case .clear:
+            return .disconnect
+        case .oauthSignInMessageRead:
+            return .show
+        }
+    }
+
+    var eventObject: TelemetryEventObject {
+        return .account
+    }
+
+    var value: String? {
+        return nil
+    }
+
+    var extras:  [String: Any?]? {
+        return nil
+    }
+}

--- a/lockbox-ios/Action/TelemetryAction.swift
+++ b/lockbox-ios/Action/TelemetryAction.swift
@@ -19,7 +19,7 @@ enum TelemetryEventCategory: String {
 }
 
 enum TelemetryEventMethod: String {
-case tap, startup, foreground, background, settingChanged, show
+case tap, startup, foreground, background, settingChanged, show, signIn, disconnect
 }
 
 enum TelemetryEventObject: String {
@@ -45,6 +45,7 @@ enum TelemetryEventObject: String {
     case loginFxa = "login_fxa"
     case loginOnboardingConfirmation = "login_onboarding_confirmation"
     case loginLearnMore = "login_learn_more"
+    case account = "account"
 }
 
 enum ExtraKey: String {

--- a/lockbox-iosTests/TelemetryStoreSpec.swift
+++ b/lockbox-iosTests/TelemetryStoreSpec.swift
@@ -58,7 +58,7 @@ class TelemetryStoreSpec: QuickSpec {
                 }
 
                 it("does not pass through non-ItemDetailDisplayActions") {
-                    self.dispatcher.fakeRegistration.onNext(AccountAction.clear)
+                    self.dispatcher.fakeRegistration.onNext(DataStoreAction.lock)
 
                     expect(telemetryObserver.events.count).to(equal(0))
                 }


### PR DESCRIPTION
resolves https://github.com/mozilla-lockbox/lockbox-ios/issues/659

This seems to work for me locally, but I wasn't sure how to handle the `oauthSignInMessageRead` case - we don't really need an event here but I don't know how to elegantly handle that in swift. If its better to just include it, then that's OK. 

BTW I didn't experience any bugs during or after having to re-login with oauth in the simulator, fwiw. (I hadn't done it since the code landed in master)

Sasha I know you're at a conference, no need to do this until you're back