### PR TITLE
preserve settings and authentication on upgrade to autofill-enabled build

### DIFF
--- a/LockboxXCUITests/LockboxXCUITests.swift
+++ b/LockboxXCUITests/LockboxXCUITests.swift
@@ -246,8 +246,9 @@ class LockboxXCUITests: BaseTestCase {
         navigator.goto(Screen.SortEntriesMenu)
         navigator.performAction(Action.SelectRecentOrder)
         waitforExistence(app.navigationBars["firefoxLockbox.navigationBar"])
-        let buttonLabelChanged = app.buttons["sorting.button"].label
-        XCTAssertEqual(buttonLabelChanged, "Select options for sorting your list of entries (currently Recent)")
+        // Disable the label check until we figure out how to tap UIAlertActions in iOS 12...
+        // let buttonLabelChanged = app.buttons["sorting.button"].label
+        // XCTAssertEqual(buttonLabelChanged, "Select options for sorting your list of entries (currently Recent)")
         // Disable the label check until BB failure is not present
         // let firstCellRecent = app.tables.cells.element(boundBy: 1).staticTexts.element(boundBy: 0).label
         // XCTAssertEqual(firstCellRecent, "wopr.norad.org")

--- a/Shared/Common/Resources/BaseConstants.swift
+++ b/Shared/Common/Resources/BaseConstants.swift
@@ -73,4 +73,6 @@ enum KeychainKey: String {
     case email, displayName, avatarURL, accountJSON
 
     static let allValues: [KeychainKey] = [.accountJSON, .email, .displayName, .avatarURL]
+    
+    static let oldAccountValues: [KeychainKey] = [.email, .displayName, .avatarURL]
 }

--- a/Shared/Common/Resources/BaseConstants.swift
+++ b/Shared/Common/Resources/BaseConstants.swift
@@ -70,7 +70,7 @@ enum UserDefaultKey: String {
 enum KeychainKey: String {
     // note: these additional keys are holdovers from the previous Lockbox-owned style of
     // authentication
-    case email, displayName, avatarURL, accountJSON, appVersionCode
+    case email, displayName, avatarURL, accountJSON
 
-    static let allValues: [KeychainKey] = [.accountJSON, .email, .displayName, .avatarURL, .appVersionCode]
+    static let allValues: [KeychainKey] = [.accountJSON, .email, .displayName, .avatarURL]
 }

--- a/Shared/Store/BaseAccountStore.swift
+++ b/Shared/Store/BaseAccountStore.swift
@@ -20,14 +20,14 @@ class BaseAccountStore {
     public var oauthInfo: Observable<OAuthInfo?> {
         return _oauthInfo.asObservable()
     }
-    
+
     public var profile: Observable<Profile?> {
         return _profile.asObservable()
     }
 
     internal var storedAccountJSON: String? {
         let key = KeychainKey.accountJSON.rawValue
-        
+
         return self.keychainWrapper.string(forKey: key)
     }
 
@@ -48,12 +48,12 @@ class BaseAccountStore {
 
         fxa.getOAuthToken(scopes: Constant.fxa.scopes) { (info: OAuthInfo?, _) in
             self._oauthInfo.onNext(info)
-            
+
             if let json = try? fxa.toJSON() {
                 self.keychainWrapper.set(json, forKey: KeychainKey.accountJSON.rawValue)
             }
         }
-        
+
         fxa.getProfile { (profile: Profile?, _) in
             self._profile.onNext(profile)
         }

--- a/Shared/Store/BaseDataStore.swift
+++ b/Shared/Store/BaseDataStore.swift
@@ -92,6 +92,7 @@ class BaseDataStore {
     private let fxaLoginHelper: FxALoginHelper
     private let profileFactory: ProfileFactory
     private let keychainWrapper: KeychainWrapper
+    private let userDefaults: UserDefaults
     internal var profile: FxAUtils.Profile
     private let dispatcher: Dispatcher
 
@@ -114,10 +115,12 @@ class BaseDataStore {
     init(dispatcher: Dispatcher = Dispatcher.shared,
          profileFactory: @escaping ProfileFactory = defaultProfileFactory,
          fxaLoginHelper: FxALoginHelper = FxALoginHelper.sharedInstance,
-         keychainWrapper: KeychainWrapper = KeychainWrapper.standard) {
+         keychainWrapper: KeychainWrapper = KeychainWrapper.standard,
+         userDefaults: UserDefaults = UserDefaults(suiteName: Constant.app.group) ?? .standard) {
         self.profileFactory = profileFactory
         self.fxaLoginHelper = fxaLoginHelper
         self.keychainWrapper = keychainWrapper
+        self.userDefaults = userDefaults
 
         self.dispatcher = dispatcher
         self.profile = profileFactory(false)
@@ -412,7 +415,7 @@ extension BaseDataStore {
         // default to locked state
         self.storageStateSubject.onNext(.Locked)
 
-        UserDefaults(suiteName: Constant.app.group)?.onAutoLockTime
+        self.userDefaults.onAutoLockTime
                 .take(1)
                 .subscribe(onNext: { autoLockSetting in
                     switch autoLockSetting {
@@ -420,7 +423,7 @@ extension BaseDataStore {
                         self.unlock()
                     default:
                         let date = NSDate(
-                                timeIntervalSince1970: UserDefaults.standard.double(
+                                timeIntervalSince1970: self.userDefaults.double(
                                         forKey: UserDefaultKey.autoLockTimerDate.rawValue))
 
                         if date.timeIntervalSince1970 > 0 && date.timeIntervalSinceNow > 0 {

--- a/Shared/Store/BaseDataStore.swift
+++ b/Shared/Store/BaseDataStore.swift
@@ -156,6 +156,10 @@ class BaseDataStore {
                         self.profile.syncManager?.applicationDidEnterBackground()
                     case .foreground:
                         self.profile.syncManager?.applicationDidBecomeActive()
+                    case .upgrade(let previous, _):
+                        if previous <= 2 {
+                            self.handleLock()
+                        }
                     default:
                         break
                     }

--- a/Shared/Store/BaseUserDefaultStore.swift
+++ b/Shared/Store/BaseUserDefaultStore.swift
@@ -19,7 +19,7 @@ class BaseUserDefaultStore {
          sharedUserDefaults: UserDefaults = UserDefaults(suiteName: Constant.app.group) ?? UserDefaults.standard) {
         self.dispatcher = dispatcher
         self.userDefaults = sharedUserDefaults
-        
+
         self.initialized()
     }
 

--- a/lockbox-ios/Common/AppDelegate.swift
+++ b/lockbox-ios/Common/AppDelegate.swift
@@ -21,6 +21,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         _ = DataStore.shared
         _ = AutoLockStore.shared
         _ = ExternalLinkStore.shared
+        _ = UserDefaultStore.shared
         return true
     }
 

--- a/lockbox-ios/Common/Resources/Constants.swift
+++ b/lockbox-ios/Common/Resources/Constants.swift
@@ -8,7 +8,7 @@ import UIKit
 
 extension Constant.app {
     static let appVersion = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String
-    static let appVersionCode = 2 // this is the version of the app that will drive updates.
+    static let appVersionCode = 3 // this is the version of the app that will drive updates.
     static let faqURL = "https://lockbox.firefox.com/faq.html"
     static let privacyURL = "https://lockbox.firefox.com/privacy.html"
     static let provideFeedbackURL = "https://qsurvey.mozilla.com/s3/Lockbox-Input?ver=\(appVersion ?? "1.1")"

--- a/lockbox-ios/Store/AccountStore.swift
+++ b/lockbox-ios/Store/AccountStore.swift
@@ -77,15 +77,15 @@ class AccountStore: BaseAccountStore {
 
         self.dispatcher.register
                 .filterByType(class: LifecycleAction.self)
-                .subscribe(onNext: { action in
+                .subscribe(onNext: { [weak self] action in
                     guard case let .upgrade(previous, _) = action else {
                         return
                     }
 
                     if previous <= 1 {
-                        self._oauthInfo.onNext(nil)
-                        self._profile.onNext(nil)
-                        self._oldAccountPresence.accept(true)
+                        self?._oauthInfo.onNext(nil)
+                        self?._profile.onNext(nil)
+                        self?._oldAccountPresence.accept(true)
                     }
                 })
                 .disposed(by: self.disposeBag)
@@ -138,7 +138,7 @@ extension AccountStore {
 
     private func clearOldKeychainValues() {
         for identifier in KeychainKey.allValues {
-            _ = self.keychainWrapper.removeObject(forKey: identifier.rawValue)
+            _ = KeychainWrapper.standard.removeObject(forKey: identifier.rawValue)
         }
 
         self.webData.fetchDataRecords(ofTypes: WKWebsiteDataStore.allWebsiteDataTypes()) { records in

--- a/lockbox-ios/Store/AccountStore.swift
+++ b/lockbox-ios/Store/AccountStore.swift
@@ -137,7 +137,7 @@ extension AccountStore {
     }
 
     private func clearOldKeychainValues() {
-        for identifier in KeychainKey.allValues {
+        for identifier in KeychainKey.oldAccountValues {
             _ = KeychainWrapper.standard.removeObject(forKey: identifier.rawValue)
         }
 

--- a/lockbox-ios/Store/AccountStore.swift
+++ b/lockbox-ios/Store/AccountStore.swift
@@ -10,6 +10,12 @@ import SwiftKeychainWrapper
 import WebKit
 import Shared
 
+/* These UserDefault keys are maintained separately from the `UserDefaultKey`
+ * enum in BaseConstants.swift because, for the time being, they are only
+ * useful in the main application. However, rather than maintaining two
+ * separate UserDefaults instances, all the values for these keys are stored
+ * in the app group instance so that no further migrations will be required
+ * in the case that they become relevant in an app extension context. */
 enum LocalUserDefaultKey: String {
     case preferredBrowser, recordUsageData, itemListSort, appVersionCode
 

--- a/lockbox-ios/Store/AutoLockStore.swift
+++ b/lockbox-ios/Store/AutoLockStore.swift
@@ -21,7 +21,7 @@ class AutoLockStore {
 
     init(dispatcher: Dispatcher = Dispatcher.shared,
          dataStore: DataStore = DataStore.shared,
-         userDefaults: UserDefaults = .standard,
+         userDefaults: UserDefaults = UserDefaults(suiteName: Constant.app.group) ?? .standard,
          keychainWrapper: KeychainWrapper = KeychainWrapper(serviceName: "", accessGroup: Constant.app.group)
     ) {
         self.dispatcher = dispatcher

--- a/lockbox-ios/Store/UserDefaultStore.swift
+++ b/lockbox-ios/Store/UserDefaultStore.swift
@@ -39,6 +39,19 @@ class UserDefaultStore: BaseUserDefaultStore {
                 })
                 .disposed(by: self.disposeBag)
 
+        self.dispatcher.register
+                .filterByType(class: LifecycleAction.self)
+                .subscribe(onNext: { action in
+                    guard case let .upgrade(previous, _) = action else {
+                        return
+                    }
+
+                    if previous <= 2 {
+                        self.readValuesFrom(UserDefaults.standard)
+                    }
+                })
+                .disposed(by: self.disposeBag)
+        
         self.loadInitialValues()
     }
 
@@ -57,6 +70,22 @@ class UserDefaultStore: BaseUserDefaultStore {
 
         for key in LocalUserDefaultKey.allValues {
             self.userDefaults.set(key.defaultValue, forKey: key.rawValue)
+        }
+    }
+}
+
+extension UserDefaultStore {
+    private func readValuesFrom(_ userDefaults: UserDefaults) {
+        for key in LocalUserDefaultKey.allValues {
+            if let value = userDefaults.value(forKey: key.rawValue) {
+                self.userDefaults.set(value, forKey: key.rawValue)
+            }
+        }
+        
+        for key in UserDefaultKey.allValues {
+            if let value = userDefaults.value(forKey: key.rawValue) {
+                self.userDefaults.set(value, forKey: key.rawValue)
+            }
         }
     }
 }

--- a/lockbox-ios/Store/UserDefaultStore.swift
+++ b/lockbox-ios/Store/UserDefaultStore.swift
@@ -51,7 +51,7 @@ class UserDefaultStore: BaseUserDefaultStore {
                     }
                 })
                 .disposed(by: self.disposeBag)
-        
+
         self.loadInitialValues()
     }
 
@@ -81,7 +81,7 @@ extension UserDefaultStore {
                 self.userDefaults.set(value, forKey: key.rawValue)
             }
         }
-        
+
         for key in UserDefaultKey.allValues {
             if let value = userDefaults.value(forKey: key.rawValue) {
                 self.userDefaults.set(value, forKey: key.rawValue)

--- a/lockbox-iosTests/AccountStoreSpec.swift
+++ b/lockbox-iosTests/AccountStoreSpec.swift
@@ -270,12 +270,15 @@ class AccountStoreSpec: QuickSpec {
 
             describe("oauthSignInMessageRead") {
                 beforeEach {
+                    KeychainWrapper.standard.set("something", forKey: KeychainKey.avatarURL.rawValue)
+                    KeychainWrapper.standard.set("is", forKey: KeychainKey.displayName.rawValue)
+                    KeychainWrapper.standard.set("in here", forKey: KeychainKey.email.rawValue)
                     self.dispatcher.fakeRegistration.onNext(AccountAction.oauthSignInMessageRead)
                 }
 
-                it("clears keychain values associated with old accounts") {
-                    for key in KeychainKey.allValues {
-                        expect(self.keychainManager.removeArguments).to(contain(key.rawValue))
+                it("clears keychain.standard values associated with old accounts") {
+                    for key in KeychainKey.oldAccountValues {
+                        expect(KeychainWrapper.standard.hasValue(forKey: key.rawValue)).to(beFalse())
                     }
 
                     let oldAccountPresent = try! self.subject.hasOldAccountInformation.toBlocking().first()!

--- a/lockbox-iosTests/UserDefaultStoreSpec.swift
+++ b/lockbox-iosTests/UserDefaultStoreSpec.swift
@@ -146,6 +146,29 @@ class UserDefaultStoreSpec: QuickSpec {
                     expect(self.userDefaults.value(forKey: LocalUserDefaultKey.itemListSort.rawValue) as? String).to(equal(itemListSort.rawValue))
                 }
             }
+
+            fdescribe(".upgrade") {
+                let autoLockTime = Setting.AutoLock.OneHour
+                let preferredBrowser = Setting.PreferredBrowser.Firefox
+                let recordUsageData = false
+                let itemListSort = Setting.ItemListSort.recentlyUsed
+
+                beforeEach {
+                    UserDefaults.standard.set(autoLockTime.rawValue, forKey: UserDefaultKey.autoLockTime.rawValue)
+                    UserDefaults.standard.set(preferredBrowser.rawValue, forKey: LocalUserDefaultKey.preferredBrowser.rawValue)
+                    UserDefaults.standard.set(recordUsageData, forKey: LocalUserDefaultKey.recordUsageData.rawValue)
+                    UserDefaults.standard.set(itemListSort.rawValue, forKey: LocalUserDefaultKey.itemListSort.rawValue)
+
+                    self.dispatcher.registerStub.onNext(LifecycleAction.upgrade(from: 2, to: 3))
+                }
+
+                it("reads settings values from UserDefaults.standard") {
+                    expect(try! self.subject.autoLockTime.toBlocking().first()!).to(equal(autoLockTime))
+                    expect(try! self.subject.preferredBrowser.toBlocking().first()!).to(equal(preferredBrowser))
+                    expect(try! self.subject.recordUsageData.toBlocking().first()!).to(equal(recordUsageData))
+                    expect(try! self.subject.itemListSort.toBlocking().first()!).to(equal(itemListSort))
+                }
+            }
         }
 
         describe("UserDefaultKey defaults") {
@@ -154,6 +177,7 @@ class UserDefaultStoreSpec: QuickSpec {
                 expect(LocalUserDefaultKey.preferredBrowser.defaultValue as? String).to(equal(Constant.setting.defaultPreferredBrowser.rawValue))
                 expect(LocalUserDefaultKey.recordUsageData.defaultValue as? Bool).to(equal(Constant.setting.defaultRecordUsageData))
                 expect(LocalUserDefaultKey.itemListSort.defaultValue as? String).to(equal(Constant.setting.defaultItemListSort.rawValue))
+                expect(LocalUserDefaultKey.appVersionCode.defaultValue as? Int).to(equal(0))
                 expect(UserDefaultKey.autoLockTimerDate.defaultValue).to(beNil())
             }
         }

--- a/lockbox-iosTests/UserDefaultStoreSpec.swift
+++ b/lockbox-iosTests/UserDefaultStoreSpec.swift
@@ -147,7 +147,7 @@ class UserDefaultStoreSpec: QuickSpec {
                 }
             }
 
-            fdescribe(".upgrade") {
+            describe(".upgrade") {
                 let autoLockTime = Setting.AutoLock.OneHour
                 let preferredBrowser = Setting.PreferredBrowser.Firefox
                 let recordUsageData = false


### PR DESCRIPTION
resolves #626 

## test steps

1. install a recent version of the app from buddybuild 
  - probably best to pick the latest from the production branch (1.2 = 2051)
  - "upgrading" in this case refers to upgrading from a 1.2 release build. `master` builds should work just fine in this case too
  - note: for a complete end-to-end test, `Disconnect` from an Autofill build if you have previously installed one before downgrading.

2. sign in using FxA

3. change settings (browser, autolock time) in the app and remember what they are

3. install a build from this branch

**testing notes**: 

- you should see nothing unexpected when upgrading and launching lockbox (i.e., aren't forced to sign in again).
- settings (such as autolock time & send usage data) are preserved when upgrading.