### PR TITLE
Add "Add a browser" documentation

### DIFF
--- a/buddybuild_postbuild.sh
+++ b/buddybuild_postbuild.sh
@@ -1,2 +1,4 @@
 #!/usr/bin/env bash
-bash <(curl -s https://codecov.io/bash) -J Lockbox -t $CODECOV_TOKEN
+if [ "$BUDDYBUILD_SCHEME" = "lockbox" ]; then
+  bash <(curl -s https://codecov.io/bash) -J Lockbox -t $CODECOV_TOKEN
+fi

--- a/docs/add-a-browser.md
+++ b/docs/add-a-browser.md
@@ -1,0 +1,49 @@
+# Add a browser setting to Firefox Lockbox
+
+_These instructions are for developers wanting to add another browser setting so when users tap to open an entry's URL it will be sent to the web browser of their choice._
+
+
+1. Find and add the query scheme the new browser has registered to `LSApplicationQueriesSchemes` in `Common/Resources/Info.plist`. For example we'll use [DuckDuckGo](https://github.com/mozilla-lockbox/lockbox-ios/compare/master...joeyg:duckduckgo?expand=1):
+
+  ```
+  <string>ddgQuickLink</string>
+  ```
+
+
+2. Then add a new case to `PreferredBrowserSetting` in `ExternalLinkAction.swift`:
+
+  ```swift
+  case DuckDuckGo
+  ```
+
+3. Define that new case in the `getPreferredBrowserDeeplink` switch statement and return the string (with that new query scheme as the expected URL syntax):
+
+  ```swift
+  case .DuckDuckGo:
+    return URL(string: "ddgQuickLink://\(url)")
+  ```
+
+3. Add a constant (string) for the name of the browser (this will be used for the setting) to `Common/Resources/Constants.swift`:
+
+  ```swift
+  static let settingsBrowserDuckDuckGo = NSLocalizedString("settings.browser.duckduckgo", value: "Duck Duck Go", comment: "Duck Duck Go Browser")
+  ```
+
+4. Then include the constant (name of the browser) to the case in the `toString()` function back in `Action/ExternalLinkAction.swift`:
+
+  ```swift
+  case .DuckDuckGo:
+    return Constant.string.settingsBrowserDuckDuckGo
+```
+
+5. Also add the name constant to the `initialSettings` variable in `Presenter/PreferredBrowserSettingPresenter.swift` so the `PreferredBrowserSettingPresenter` class can mark the browser as "checked" when selected:
+
+  ```swift
+  lazy var initialSettings = [
+    CheckmarkSettingCellConfiguration(text: Constant.string.settingsBrowserDuckDuckGo,
+    valueWhenChecked: PreferredBrowserSetting.DuckDuckGo),
+  ```
+  
+That's it!
+
+If you'd like to contribute a patch with the above, or anything else, please read our [contributing guidelines](contributing.md).

--- a/docs/add-a-browser.md
+++ b/docs/add-a-browser.md
@@ -16,7 +16,7 @@ _These instructions are for developers wanting to add another browser setting so
   case DuckDuckGo
   ```
 
-3. Define that new case in the `getPreferredBrowserDeeplink` switch statement and return the string (with that new query scheme as the expected URL syntax):
+3. Define that new case in the `getPreferredBrowserDeeplink` switch statement and return the string with that new query scheme as the expected URL syntax. Keep in mind you may need to encode the URLs and test some links to make sure they open as expected on a real device with the browser installed:
 
   ```swift
   case .DuckDuckGo:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -4,14 +4,19 @@ theme: readthedocs
 repo_name: GitHub
 repo_url: https://github.com/mozilla-lockbox/lockbox-ios
 
-pages:
+      
+nav:
 - 'Introduction': 'index.md'
 - 'Release Notes': 'release-notes.md'
-- 'Contributing': 'contributing.md'
+- 'How to Contribute': 
+  - 'Contributing': 'contributing.md'
+  - 'Code of Conduct': 'code_of_conduct.md'
 - 'Telemetry and Metrics': 'metrics.md'
 - 'Developer Guides':
   - 'Build and Install': 'install.md'
   - 'Architecture': 'architecture.md'
   - 'Dependencies': 'updating_libraries.md'
-  - 'Add a browser': 'add-a-browser.md'
+  - 'How to: add a browser': 'add-a-browser.md'
+  - 'How to: add a UI feature': 'new-ui.md'
+  - 'Test Plan': 'test-plan.md'
   - 'Release Instructions': 'releases.md'

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -4,7 +4,6 @@ theme: readthedocs
 repo_name: GitHub
 repo_url: https://github.com/mozilla-lockbox/lockbox-ios
 
-      
 nav:
 - 'Introduction': 'index.md'
 - 'Release Notes': 'release-notes.md'

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -13,4 +13,5 @@ pages:
   - 'Build and Install': 'install.md'
   - 'Architecture': 'architecture.md'
   - 'Dependencies': 'updating_libraries.md'
+  - 'Add a browser': 'add-a-browser.md'
   - 'Release Instructions': 'releases.md'


### PR DESCRIPTION
Fixes #546 

This adds a new documentation page based on @joeyg's example branch:
https://github.com/mozilla-lockbox/lockbox-ios/compare/master...joeyg:duckduckgo?expand=1

I think I technically worded this doc correctly but would appreciate a review from @joeyg or @mozilla-lockbox/mobile-engineering.

Note: the readthedocs theme doesn't do a great job with the code formatting:

<img width="959" alt="screen shot 2018-08-30 at 3 34 56 pm" src="https://user-images.githubusercontent.com/49511/44880732-96b8bb80-ac6a-11e8-954b-6cfcc898febd.png">

...but it looks great in rendered markdown (which folks can get to from this repo, or from the website clicking the 'Edit in GitHub' link):

<img width="578" alt="screen shot 2018-08-30 at 3 36 57 pm" src="https://user-images.githubusercontent.com/49511/44880728-928c9e00-ac6a-11e8-8955-07a3d8f890a9.png">

So I think its fine as it is but open to easy wins before merging.