### PR TITLE
Size Lock Now button for dynamic type

### DIFF
--- a/lockbox-ios/Common/Extensions/UIView+.swift
+++ b/lockbox-ios/Common/Extensions/UIView+.swift
@@ -5,17 +5,9 @@
 import UIKit
 
 extension UIView {
-    func addTopBorderWithColor(color: UIColor, width: CGFloat) {
-        let border = CALayer()
-        border.backgroundColor = color.cgColor
-        border.frame = CGRect(x: 0, y: 0, width: self.frame.size.width, height: width)
-        self.layer.addSublayer(border)
-    }
-
-    func addBottomBorderWithColor(color: UIColor, width: CGFloat) {
-        let border = CALayer()
-        border.backgroundColor = color.cgColor
-        border.frame = CGRect(x: 0, y: self.frame.size.height - width, width: self.frame.size.width, height: width)
-        self.layer.addSublayer(border)
+    /** Sets the view's border color and width. */
+    func setBorder(color: UIColor, width: CGFloat) {
+        self.layer.borderColor = color.cgColor
+        self.layer.borderWidth = width
     }
 }

--- a/lockbox-ios/Presenter/SettingListPresenter.swift
+++ b/lockbox-ios/Presenter/SettingListPresenter.swift
@@ -10,7 +10,7 @@ import LocalAuthentication
 
 protocol SettingListViewProtocol: class, AlertControllerView {
     func bind(items: Driver<[SettingSectionModel]>)
-    var onSignOut: ControlEvent<Void> { get }
+    var onLockNow: ControlEvent<Void> { get }
 }
 
 class SettingListPresenter {
@@ -113,7 +113,7 @@ class SettingListPresenter {
 
         self.view?.bind(items: settingsConfigDriver)
 
-        self.view?.onSignOut
+        self.view?.onLockNow
                 .subscribe { _ in
                     if self.biometryManager.deviceAuthenticationAvailable {
                         self.dispatcher.dispatch(action: DataStoreAction.lock)

--- a/lockbox-ios/Storyboard/Base.lproj/SettingList.storyboard
+++ b/lockbox-ios/Storyboard/Base.lproj/SettingList.storyboard
@@ -29,7 +29,7 @@
                                             <rect key="frame" x="0.0" y="0.0" width="375" height="44"/>
                                             <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                             <constraints>
-                                                <constraint firstAttribute="height" constant="44" id="Vkm-HP-o1P"/>
+                                                <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="44" id="Vkm-HP-o1P"/>
                                             </constraints>
                                             <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                             <state key="normal" title="Lock Now">
@@ -41,9 +41,10 @@
                                         </button>
                                     </subviews>
                                     <constraints>
-                                        <constraint firstItem="KPq-Rv-WTJ" firstAttribute="leading" secondItem="evG-dP-9fl" secondAttribute="leading" id="XTr-Yx-P0Y"/>
-                                        <constraint firstAttribute="trailing" secondItem="KPq-Rv-WTJ" secondAttribute="trailing" id="fH9-j8-mzi"/>
-                                        <constraint firstAttribute="bottom" secondItem="KPq-Rv-WTJ" secondAttribute="bottom" id="v3e-9O-rM1"/>
+                                        <constraint firstItem="KPq-Rv-WTJ" firstAttribute="leading" secondItem="evG-dP-9fl" secondAttribute="leading" id="54g-sq-kp6"/>
+                                        <constraint firstAttribute="bottom" secondItem="KPq-Rv-WTJ" secondAttribute="bottom" id="DHG-KP-Rqe"/>
+                                        <constraint firstAttribute="trailing" secondItem="KPq-Rv-WTJ" secondAttribute="trailing" id="JIJ-UR-sKi"/>
+                                        <constraint firstItem="KPq-Rv-WTJ" firstAttribute="top" secondItem="evG-dP-9fl" secondAttribute="top" id="Ucx-uv-VtU"/>
                                     </constraints>
                                 </view>
                                 <prototypes>
@@ -67,7 +68,7 @@
                         <viewLayoutGuide key="safeArea" id="1cT-6d-0cg"/>
                     </view>
                     <connections>
-                        <outlet property="signOutButton" destination="KPq-Rv-WTJ" id="JYJ-RB-n9t"/>
+                        <outlet property="lockNowButton" destination="KPq-Rv-WTJ" id="ghO-8v-elv"/>
                         <outlet property="tableView" destination="lcM-sN-0rK" id="bkh-nq-W3I"/>
                     </connections>
                 </viewController>

--- a/lockbox-ios/View/AccountSettingView.swift
+++ b/lockbox-ios/View/AccountSettingView.swift
@@ -52,8 +52,7 @@ extension AccountSettingView: AccountSettingViewProtocol {
 
 extension AccountSettingView: UIGestureRecognizerDelegate {
     fileprivate func setupUnlinkAccountButton() {
-        self.unlinkAccountButton.addTopBorderWithColor(color: Constant.color.cellBorderGrey, width: 0.5)
-        self.unlinkAccountButton.addBottomBorderWithColor(color: Constant.color.cellBorderGrey, width: 0.5)
+        self.unlinkAccountButton.setBorder(color: Constant.color.cellBorderGrey, width: 0.5)
 
         if let presenter = self.presenter {
             self.unlinkAccountButton.rx.tap

--- a/lockbox-iosTests/SettingListPresenterSpec.swift
+++ b/lockbox-iosTests/SettingListPresenterSpec.swift
@@ -30,7 +30,7 @@ class SettingListPresenterSpec: QuickSpec {
             items.drive(itemsObserver).disposed(by: disposeBag)
         }
 
-        var onSignOut: ControlEvent<Void> {
+        var onLockNow: ControlEvent<Void> {
             return ControlEvent(events: fakeButtonPress.asObservable())
         }
     }

--- a/lockbox-iosTests/SettingListViewSpec.swift
+++ b/lockbox-iosTests/SettingListViewSpec.swift
@@ -145,15 +145,15 @@ class SettingListViewSpec: QuickSpec {
                 }
             }
 
-            describe("onSignOut") {
+            describe("onLockNow") {
                 var observer = self.scheduler.createObserver(Void.self)
 
                 beforeEach {
                     observer = self.scheduler.createObserver(Void.self)
 
-                    self.subject.onSignOut.subscribe(observer).disposed(by: self.disposeBag)
+                    self.subject.onLockNow.subscribe(observer).disposed(by: self.disposeBag)
 
-                    self.subject.signOutButton.sendActions(for: .touchUpInside)
+                    self.subject.lockNowButton.sendActions(for: .touchUpInside)
                 }
 
                 it("tells any observers") {


### PR DESCRIPTION
Address "Lock Now" button scaling issues in #512. Connected to #512

### Footer view sizing
Apparently, TableView's footer view would not resize for the internal content size changes. Thus we have to manually trigger its resize. See: https://collindonnell.com/2015/09/29/dynamically-sized-table-view-header-or-footer-using-auto-layout/ and https://lists.apple.com/archives/cocoa-dev/2014/Jun/msg00127.html.

### Borders
Borders layers are not resized with the view. Thus if we scale the view, the bottom border would still be drawn at the old position, now in the middle of the view. For this we have two options:
1. Keep a reference to added layers, and layout them together with the view.
1. Display a border as part of the view layer, which is automatically sized.
Since the footer is full width, it is safe to simply set the border on the view.

### Results
| Minimum font size | Maximum font size |
| ------------------ | ------------------- |
| ![min](https://user-images.githubusercontent.com/1129082/44999860-a7e22f00-afc0-11e8-845a-a9e2cbbe4759.png) | ![max](https://user-images.githubusercontent.com/1129082/44999864-aadd1f80-afc0-11e8-9ada-5200ed0c5c50.png) |
