### PR TITLE
populate the credential store every time the app is unlocked

### DIFF
--- a/lockbox-ios/Common/AppDelegate.swift
+++ b/lockbox-ios/Common/AppDelegate.swift
@@ -22,6 +22,9 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         _ = AutoLockStore.shared
         _ = ExternalLinkStore.shared
         _ = UserDefaultStore.shared
+        if #available(iOS 12, *) {
+            _ = CredentialProviderStore.shared
+        }
         return true
     }
 

--- a/lockbox-ios/Presenter/RootPresenter.swift
+++ b/lockbox-ios/Presenter/RootPresenter.swift
@@ -102,6 +102,7 @@ class RootPresenter {
                     self.dispatcher.dispatch(action: LoginRouteAction.welcome)
                 case .Unlocked:
                     self.dispatcher.dispatch(action: MainRouteAction.list)
+                    self.dispatcher.dispatch(action: CredentialProviderAction.refresh)
                 default:
                     break
                 }

--- a/lockbox-iosTests/RootPresenterSpec.swift
+++ b/lockbox-iosTests/RootPresenterSpec.swift
@@ -264,7 +264,9 @@ class RootPresenterSpec: QuickSpec {
                     self.dataStore.storageStateStub.onNext(LoginStoreState.Unlocked)
                 }
 
-                it("routes to the list") {
+                it("routes to the list and refreshes the credential provider store") {
+                    let credArg = self.dispatcher.dispatchActionArgument.popLast() as! CredentialProviderAction
+                    expect(credArg).to(equal(CredentialProviderAction.refresh))
                     let arg = self.dispatcher.dispatchActionArgument.popLast() as! MainRouteAction
                     expect(arg).to(equal(MainRouteAction.list))
                 }


### PR DESCRIPTION
resolves #613 
resolves #614 

note that we are doing "stupid refreshing" right now -- we clear and re-populate the entire credential store, every time the app unlocks rather than something more optimized.

**testing notes**

- _without signing in to the app_, enable Lockbox as a credential provider
- enable Lockbox as a credential provider
- authenticate in Lockbox.app

expected: you see the credentials from Lockbox show up in the QuickType bar.