### PR TITLE
Fix Safari UI test (3)

### DIFF
--- a/LockboxXCUITests/LockboxXCUITests.swift
+++ b/LockboxXCUITests/LockboxXCUITests.swift
@@ -201,6 +201,7 @@ class LockboxXCUITests: BaseTestCase {
         // Safari is open
         let safari = XCUIApplication(bundleIdentifier: "com.apple.mobilesafari")
 
+        waitforExistence(safari.buttons["URL"])
         let urlValue = safari.buttons["URL"].value as! String
         waitForValueContains(safari.buttons["URL"], value: "accounts")
 


### PR DESCRIPTION
After talking to @isabelrios I wanted to quickly add this to the autofill branch so we can "get green" and confident everything is still working as expected before we wrap it up.

By waiting for the existing of the buttons, even if the page takes a while to load, the test should continue and pass much more consistently now.