### PR TITLE
Add new AutoFill screen to UI tests

### DIFF
--- a/LockboxXCUITests/LockboxXCUITests.swift
+++ b/LockboxXCUITests/LockboxXCUITests.swift
@@ -126,6 +126,10 @@ class LockboxXCUITests: BaseTestCase {
             }
             group.wait()
         }
+        if #available(iOS 12.0, *) {
+            waitforExistence(app.buttons["setupAutofill.button"])
+            app.buttons["notNow.button"].tap()
+        }
         waitforExistence(app.buttons["finish.button"])
         app.buttons["finish.button"].tap()
 


### PR DESCRIPTION
Fixes #689 

<img width="362" alt="image" src="https://user-images.githubusercontent.com/49511/45314377-cc716600-b4ee-11e8-8d81-d408ac6c277c.png">

Tested locally both on iPhone X with iOS 12 and iPhone SE on iOS 10. ✅ 