### PR TITLE
Document AutoFill manual test cases for reference

### DIFF
--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -1,5 +1,11 @@
 # Release Notes
 
+## 1.3 (Build 2259)
+
+You now have the ability to automatically fill your username and password into apps and websites.
+
+Be sure to enable AutoFill after updating to iOS 12 in "Settings" under the "Passwords & Accounts" section.
+
 ## 1.2 (Build 2016)
 
 _Date: 2018-08-27_

--- a/docs/test-plan-autofill.md
+++ b/docs/test-plan-autofill.md
@@ -16,9 +16,6 @@
 
 2. **Enable AutoFill** (locked app): does prompt for biometrics, show spinner screen
 
-  - first try: does prompt
-  - disable and re-enable second time: double biometrics prompt weirdness
-
 3. **Enable AutoFill** (unlocked app): does not prompt for biometrics, show spinner screen
 
 4. **Enable AutoFill then cancel biometrics**: does prompt then take back to settings
@@ -36,10 +33,5 @@
 10. **QTB tap into entry list** (unlocked): does not prompt for biometrics
 
 11. **QTB tap into entry list** (locked): does prompt for biometrics
-
-  - Twitter app: double biometrics prompt
-  - Twitter app: do it a second time: entry list and app are unlocked
-  - Safari app: double biometrics prompt
-  - Safari app: double biometrics prompt: entry list and app are still locked
 
 12. **Cancel QTB tap-to-fill** (locked): does prompt for biometrics then go back to app/website

--- a/docs/test-plan-autofill.md
+++ b/docs/test-plan-autofill.md
@@ -1,0 +1,45 @@
+# Test Plan for iOS 12 AutoFill
+
+## Getting to "clean state" for testing
+
+- Disconnect
+- Disable "Lockbox" in AutoFill
+- Turn off AutoFill entirely
+- Delete app
+- Install production version 1.2 (2051)
+- Sign in
+- Install master version 1.3 (2224+)
+
+## Core test cases and expected results
+
+1. **Upgrade from 1.2 to 1.3** (locked or unlocked): does not require FxA sign in, prompts for biometrics to unlock otherwise straight to entry list
+
+2. **Enable AutoFill** (locked app): does prompt for biometrics, show spinner screen
+
+  - first try: does prompt
+  - disable and re-enable second time: double biometrics prompt weirdness
+
+3. **Enable AutoFill** (unlocked app): does not prompt for biometrics, show spinner screen
+
+4. **Enable AutoFill then cancel biometrics**: does prompt then take back to settings
+
+5. **Open App** (manually locked app): does prompt for biometrics
+
+6. **Open App** (timer locked): does prompt
+
+7. **Open App** (unlocked during autofill enabling): does prompt (again)
+
+8. **Safari QuickType tap-to-fill** (unlocked app): does (system) prompt for biometrics
+
+9. **Safari QuickType tap-to-fill** (locked app): does (system) prompt for biometrics
+
+10. **QTB tap into entry list** (unlocked): does not prompt for biometrics
+
+11. **QTB tap into entry list** (locked): does prompt for biometrics
+
+  - Twitter app: double biometrics prompt
+  - Twitter app: do it a second time: entry list and app are unlocked
+  - Safari app: double biometrics prompt
+  - Safari app: double biometrics prompt: entry list and app are still locked
+
+12. **Cancel QTB tap-to-fill** (locked): does prompt for biometrics then go back to app/website


### PR DESCRIPTION
Drafting a doc on what all the test scenarios are for AutoFill

## [Click here to view the doc](https://github.com/mozilla-lockbox/lockbox-ios/blob/autofill-testing/docs/test-plan-autofill.md)

Will add to this if needed before we finish up this feature