### PR TITLE
Filter naively based upon hostname of the entry

### DIFF
--- a/CredentialProvider/Presenter/CredentialProviderPresenter.swift
+++ b/CredentialProvider/Presenter/CredentialProviderPresenter.swift
@@ -130,13 +130,8 @@ class CredentialProviderPresenter {
                         self?.view?.displayWelcome()
                     } else {
                         self?.view?.displayItemList()
-//                        guard let dismissObserver = self?.dismissObserver else { return }
-//                        self?.view?.displayAlertController(buttons: [
-//                                AlertActionButtonConfiguration(title: "OK", tapObserver: dismissObserver, style: .default)
-//                            ],
-//                                                          title: "Credential list not available yet",
-//                                                          message: "Please check back later",
-//                                                          style: .alert)
+                        let ids = serviceIdentifiers.map { $0.identifier }
+                        self?.dispatcher.dispatch(action: ItemListFilterByIdAction(identifiers: ids))
                     }
                 }
                 .disposed(by: self.disposeBag)

--- a/Shared/Action/ItemListDisplayAction.swift
+++ b/Shared/Action/ItemListDisplayAction.swift
@@ -17,3 +17,7 @@ struct ItemListFilterEditAction: ItemListDisplayAction {
 struct PullToRefreshAction: ItemListDisplayAction {
     let refreshing: Bool
 }
+
+struct ItemListFilterByIdAction: ItemListDisplayAction {
+    let identifiers: [String]?
+}

--- a/lockbox-ios/Presenter/ItemListPresenter.swift
+++ b/lockbox-ios/Presenter/ItemListPresenter.swift
@@ -142,6 +142,8 @@ class ItemListPresenter: BaseItemListPresenter {
 
         self.setupPullToRefresh(pullToRefreshActiveObserver)
         self.dispatcher.dispatch(action: PullToRefreshAction(refreshing: false))
+
+        self.dispatcher.dispatch(action: ItemListFilterByIdAction(identifiers: nil))
     }
 }
 

--- a/lockbox-iosTests/ItemListPresenterSpec.swift
+++ b/lockbox-iosTests/ItemListPresenterSpec.swift
@@ -153,6 +153,7 @@ class ItemListPresenterSpec: QuickSpec {
                         self.subject.onViewReady()
                         self.dataStore.itemListStub.onNext([])
                         self.itemListDisplayStore.itemListDisplaySubject.onNext(ItemListFilterAction(filteringText: ""))
+                        self.itemListDisplayStore.itemListDisplaySubject.onNext(ItemListFilterByIdAction(identifiers: nil))
                         self.userDefaultStore.itemListSortStub.onNext(Setting.ItemListSort.alphabetically)
                     }
 
@@ -286,6 +287,7 @@ class ItemListPresenterSpec: QuickSpec {
                         self.subject.onViewReady()
                         self.dataStore.itemListStub.onNext(items)
                         self.itemListDisplayStore.itemListDisplaySubject.onNext(ItemListFilterAction(filteringText: ""))
+                        self.itemListDisplayStore.itemListDisplaySubject.onNext(ItemListFilterByIdAction(identifiers: nil))
                         self.userDefaultStore.itemListSortStub.onNext(Setting.ItemListSort.alphabetically)
                         self.dataStore.syncStateStub.onNext(SyncState.Synced)
                         self.dataStore.storageStateStub.onNext(LoginStoreState.Unlocked)


### PR DESCRIPTION
Fixes #712.

This PR filters the entries by hostname. Some fuzzy matching is done to allow for services to use subdomains for mobile versions of the site.

This does not match on scheme.