### PR TITLE
Hide learn more links if there is no observer for them in the item list presenter

### DIFF
--- a/CredentialProvider/Presenter/CredentialItemListPresenter.swift
+++ b/CredentialProvider/Presenter/CredentialItemListPresenter.swift
@@ -14,6 +14,10 @@ class ItemListPresenter: BaseItemListPresenter {
         return self.baseView as? ItemListViewProtocol
     }
 
+    override var learnMoreObserver: AnyObserver<Void>? { return nil }
+
+    override var learnMoreNewEntriesObserver: AnyObserver<Void>? { return nil }
+
     override var itemSelectedObserver: AnyObserver<String?> {
         return Binder(self) { target, itemId in
             guard let id = itemId else {

--- a/Shared/Presenter/BaseItemListPresenter.swift
+++ b/Shared/Presenter/BaseItemListPresenter.swift
@@ -44,11 +44,11 @@ class BaseItemListPresenter {
         fatalError("not implemented!")
     }
 
-    internal var learnMoreObserver: AnyObserver<Void> {
+    internal var learnMoreObserver: AnyObserver<Void>? {
         fatalError("not implemented!")
     }
 
-    internal var learnMoreNewEntriesObserver: AnyObserver<Void> {
+    internal var learnMoreNewEntriesObserver: AnyObserver<Void>? {
         fatalError("not implemented!")
     }
 

--- a/Shared/View/BaseItemListView.swift
+++ b/Shared/View/BaseItemListView.swift
@@ -13,8 +13,8 @@ enum LoginListCellConfiguration {
     case Search(enabled: Observable<Bool>, cancelHidden: Observable<Bool>, text: Observable<String>)
     case Item(title: String, username: String, guid: String)
     case SyncListPlaceholder
-    case EmptyListPlaceholder(learnMoreObserver: AnyObserver<Void>)
-    case NoResults(learnMoreObserver: AnyObserver<Void>)
+    case EmptyListPlaceholder(learnMoreObserver: AnyObserver<Void>?)
+    case NoResults(learnMoreObserver: AnyObserver<Void>?)
 }
 
 extension LoginListCellConfiguration: IdentifiableType {
@@ -173,20 +173,26 @@ extension BaseItemListView {
                             fatalError("couldn't find the right cell!")
                         }
 
-                        cell.learnMoreButton.rx.tap
-                                .bind(to: learnMoreObserver)
-                                .disposed(by: cell.disposeBag)
-
+                        if let observer = learnMoreObserver {
+                            cell.learnMoreButton.rx.tap
+                                    .bind(to: observer)
+                                    .disposed(by: cell.disposeBag)
+                        } else {
+                            cell.learnMoreButton.isHidden = true
+                        }
                         retCell = cell
                     case .NoResults(let learnMoreObserver):
                         guard let cell = tableView.dequeueReusableCell(withIdentifier: "noresultsplaceholder") as? NoResultsCell else {
                             fatalError("couldn't find the no results cell")
                         }
 
-                        cell.learnMoreButton.rx.tap
-                            .bind(to: learnMoreObserver)
-                            .disposed(by: cell.disposeBag)
-
+                        if let observer = learnMoreObserver {
+                            cell.learnMoreButton.rx.tap
+                                .bind(to: observer)
+                                .disposed(by: cell.disposeBag)
+                        } else {
+                            cell.learnMoreButton.isHidden = true
+                        }
                         retCell = cell
                     }
 

--- a/lockbox-ios/Presenter/ItemListPresenter.swift
+++ b/lockbox-ios/Presenter/ItemListPresenter.swift
@@ -93,7 +93,7 @@ class ItemListPresenter: BaseItemListPresenter {
         }.asObserver()
     }()
 
-    override var learnMoreObserver: AnyObserver<Void> {
+    override var learnMoreObserver: AnyObserver<Void>? {
         return Binder(self) { target, _ in
             target.dispatcher.dispatch(action: ExternalWebsiteRouteAction(
                     urlString: Constant.app.enableSyncFAQ,
@@ -102,7 +102,7 @@ class ItemListPresenter: BaseItemListPresenter {
         }.asObserver()
     }
 
-    override var learnMoreNewEntriesObserver: AnyObserver<Void> {
+    override var learnMoreNewEntriesObserver: AnyObserver<Void>? {
         return Binder(self) { target, _ in
             target.dispatcher.dispatch(action: ExternalWebsiteRouteAction(
                 urlString: Constant.app.createNewEntriesFAQ,

--- a/lockbox-iosTests/ItemListPresenterSpec.swift
+++ b/lockbox-iosTests/ItemListPresenterSpec.swift
@@ -218,7 +218,7 @@ class ItemListPresenterSpec: QuickSpec {
                                     let configuration = self.view.itemsObserver.events.last!.value.element
                                     let emptyListPlaceholder = configuration!.first!.items[1]
                                     if case let .EmptyListPlaceholder(learnMoreObserver) = emptyListPlaceholder {
-                                        learnMoreObserver.onNext(())
+                                        learnMoreObserver!.onNext(())
                                     } else {
                                         fail("wrong item configuration!")
                                     }


### PR DESCRIPTION
Fixes #723. 

Make the "Learn More" observers optionals, and then use their presence when configuring the table cells to set whether or not the "Learn More >" links should be hidden. 

Learn more observers are then set to `nil` in the `CredentialItemListPresenter`.