### PR TITLE
Closes #439: Scroll to top

### DIFF
--- a/Lockbox.xcodeproj/project.pbxproj
+++ b/Lockbox.xcodeproj/project.pbxproj
@@ -126,6 +126,8 @@
 		7AA54EC7A9CA9BBD57AFEAF9 /* FilterCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7AA54B0FC602D0A79D87D3BD /* FilterCell.swift */; };
 		7AA54EEAB64EF8D9A7F48739 /* CopyDisplayStoreSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7AA543307459610B170AFBD5 /* CopyDisplayStoreSpec.swift */; };
 		7AA54FF1E300E6DEEFD77717 /* UIColor+Spec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7AA54EDDE9ECFDD6DFC4DEC5 /* UIColor+Spec.swift */; };
+		7B50F371215A52B900ADC28D /* ScrollAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B50F370215A52B900ADC28D /* ScrollAction.swift */; };
+		7B50F372215BE13100ADC28D /* ScrollAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B50F370215A52B900ADC28D /* ScrollAction.swift */; };
 		7D078EE72124DC5800D10D1B /* UserDefaults+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D078EE62124DC5800D10D1B /* UserDefaults+.swift */; };
 		7D078EE92124DC9300D10D1B /* BiometryManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7AA5408D5D52952F11E20EEC /* BiometryManager.swift */; };
 		7D078EEB2124DCE100D10D1B /* SettingAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D078EEA2124DCE100D10D1B /* SettingAction.swift */; };
@@ -482,6 +484,7 @@
 		7AA54FD51CE484EAF78B4324 /* SettingNavigationController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SettingNavigationController.swift; sourceTree = "<group>"; };
 		7AA54FE4F9D6DAEF984F63E6 /* Observable+.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Observable+.swift"; sourceTree = "<group>"; };
 		7AA54FFBEBCACA7A506F5C16 /* DispatcherSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DispatcherSpec.swift; sourceTree = "<group>"; };
+		7B50F370215A52B900ADC28D /* ScrollAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScrollAction.swift; sourceTree = "<group>"; };
 		7D078EE62124DC5800D10D1B /* UserDefaults+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UserDefaults+.swift"; sourceTree = "<group>"; };
 		7D078EEA2124DCE100D10D1B /* SettingAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingAction.swift; sourceTree = "<group>"; };
 		7D078EEE2124DF6500D10D1B /* BaseAccountStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseAccountStore.swift; sourceTree = "<group>"; };
@@ -779,12 +782,12 @@
 		7AA54792ED918CF9CE82AED0 /* Action */ = {
 			isa = PBXGroup;
 			children = (
-				7AA54E38ACC2FDBBF700D5E1 /* RouteAction.swift */,
-				7AA54D4E439D76B910034E2A /* ErrorAction.swift */,
 				7AA5492DA3988625D1DAB5BD /* AccountAction.swift */,
-				7AA54B41C60F04FA585E5B8F /* ItemDetailAction.swift */,
 				7AA54575C8FE51664E45ACD8 /* CopyAction.swift */,
+				7AA54D4E439D76B910034E2A /* ErrorAction.swift */,
 				D8783612207C080300C19BC7 /* ExternalLinkAction.swift */,
+				7AA54B41C60F04FA585E5B8F /* ItemDetailAction.swift */,
+				7AA54E38ACC2FDBBF700D5E1 /* RouteAction.swift */,
 				7D078EEA2124DCE100D10D1B /* SettingAction.swift */,
 			);
 			path = Action;
@@ -881,6 +884,7 @@
 		7D078EE22124DC1800D10D1B /* Action */ = {
 			isa = PBXGroup;
 			children = (
+				7B50F370215A52B900ADC28D /* ScrollAction.swift */,
 				7AA547479EBD794467A4A4DF /* ApplicationLifecycleAction.swift */,
 				7AA5432C1975C7E9053A5CF3 /* TelemetryAction.swift */,
 				7AA54549204186237036B464 /* DataStoreAction.swift */,
@@ -1647,6 +1651,7 @@
 				7D6FB87B204F00E2005E23AA /* StatusAlert.swift in Sources */,
 				224A6C7D212C8C2B008C7A3F /* UIFont+.swift in Sources */,
 				D86A307620829B7F00589CA8 /* UIApplication+.swift in Sources */,
+				7B50F371215A52B900ADC28D /* ScrollAction.swift in Sources */,
 				7AA548BBE384D40397D26E9B /* RootView.swift in Sources */,
 				7D9722C62134622F0071D82B /* BaseWelcomePresenter.swift in Sources */,
 				7D1B22062033C5880098C3A3 /* ItemDetailPresenter.swift in Sources */,
@@ -1758,6 +1763,7 @@
 				7DB9DE9A2140CB0000239D31 /* ItemListCell.swift in Sources */,
 				7D9722CC213485840071D82B /* StatusAlert.swift in Sources */,
 				7D9722C72134622F0071D82B /* BaseWelcomePresenter.swift in Sources */,
+				7B50F372215BE13100ADC28D /* ScrollAction.swift in Sources */,
 				7D09B24C2125DDC200794CA2 /* ApplicationLifecycleAction.swift in Sources */,
 				7DB9DE972140C5F400239D31 /* BaseItemListPresenter.swift in Sources */,
 				7D078EF62124E48300D10D1B /* Observable+.swift in Sources */,

--- a/Shared/Action/ScrollAction.swift
+++ b/Shared/Action/ScrollAction.swift
@@ -1,0 +1,22 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import Foundation
+
+/*
+ * ScrollAction is an enum in case there are further automated scroll actions that
+ * are needed in future.
+ */
+enum ScrollAction: Action {
+    case toTop
+}
+
+extension ScrollAction: Equatable {
+    static func ==(lhs: ScrollAction, rhs: ScrollAction) -> Bool {
+        switch(lhs, rhs) {
+        case (.toTop, .toTop):
+            return true
+        }
+    }
+}

--- a/lockbox-ios/Presenter/ItemListPresenter.swift
+++ b/lockbox-ios/Presenter/ItemListPresenter.swift
@@ -29,7 +29,7 @@ class ItemListPresenter: BaseItemListPresenter {
         return self.baseView as? ItemListViewProtocol
     }
     
-    lazy private var listSortedObserver: AnyObserver<Setting.ItemListSort> = {
+    lazy private(set) var listSortedObserver: AnyObserver<Setting.ItemListSort> = {
         return Binder(self) { target, _ in
             target.dispatcher.dispatch(action: ScrollAction.toTop)
         }.asObserver()

--- a/lockbox-ios/View/ItemListView.swift
+++ b/lockbox-ios/View/ItemListView.swift
@@ -57,6 +57,15 @@ extension ItemListView: ItemListViewProtocol {
                 .disposed(by: self.disposeBag)
         }
     }
+    
+    func bind(sortChanged: Driver<Setting.ItemListSort>) {
+        sortChanged.delay(RxTimeInterval(0.1))
+                   .distinctUntilChanged()
+                    .drive(onNext: { (_sort) in
+                        self.scrollToTop()
+                    }, onCompleted: nil, onDisposed: nil)
+                    .disposed(by: self.disposeBag)
+    }
 
     var tableViewScrollEnabled: AnyObserver<Bool> {
         return self.tableView.rx.isScrollEnabled.asObserver()
@@ -100,6 +109,10 @@ extension ItemListView {
                 .bind(to: presenter.refreshObserver)
                 .disposed(by: self.disposeBag)
         }
+    }
+    
+    func scrollToTop() {
+        self.tableView.scrollToRow(at: IndexPath(row: 0, section: 0), at: .none, animated: true)
     }
 }
 

--- a/lockbox-ios/View/ItemListView.swift
+++ b/lockbox-ios/View/ItemListView.swift
@@ -58,13 +58,8 @@ extension ItemListView: ItemListViewProtocol {
         }
     }
     
-    func bind(sortChanged: Driver<Setting.ItemListSort>) {
-        sortChanged.delay(RxTimeInterval(0.1))
-                   .distinctUntilChanged()
-                    .drive(onNext: { (_sort) in
-                        self.scrollToTop()
-                    }, onCompleted: nil, onDisposed: nil)
-                    .disposed(by: self.disposeBag)
+    func scrollToTop() {
+        self.tableView.scrollToRow(at: IndexPath(row: 0, section: 0), at: .none, animated: true)
     }
 
     var tableViewScrollEnabled: AnyObserver<Bool> {
@@ -109,10 +104,6 @@ extension ItemListView {
                 .bind(to: presenter.refreshObserver)
                 .disposed(by: self.disposeBag)
         }
-    }
-    
-    func scrollToTop() {
-        self.tableView.scrollToRow(at: IndexPath(row: 0, section: 0), at: .none, animated: true)
     }
 }
 

--- a/lockbox-ios/View/ItemListView.swift
+++ b/lockbox-ios/View/ItemListView.swift
@@ -58,8 +58,16 @@ extension ItemListView: ItemListViewProtocol {
         }
     }
     
-    func scrollToTop() {
-        self.tableView.scrollToRow(at: IndexPath(row: 0, section: 0), at: .none, animated: true)
+    func bind(scrollAction: Driver<ScrollAction>) {
+        scrollAction.drive(onNext: { action in
+            switch action {
+            case .toTop:
+                DispatchQueue.main.async {
+                    self.tableView.scrollToRow(at: IndexPath(row: 0, section: 0), at: .none, animated: true)
+                }
+            }
+        })
+        .disposed(by: self.disposeBag)
     }
 
     var tableViewScrollEnabled: AnyObserver<Bool> {

--- a/lockbox-ios/View/ItemListView.swift
+++ b/lockbox-ios/View/ItemListView.swift
@@ -59,15 +59,14 @@ extension ItemListView: ItemListViewProtocol {
     }
     
     func bind(scrollAction: Driver<ScrollAction>) {
-        scrollAction.drive(onNext: { action in
-            switch action {
-            case .toTop:
-                DispatchQueue.main.async {
-                    self.tableView.scrollToRow(at: IndexPath(row: 0, section: 0), at: .none, animated: true)
-                }
-            }
-        })
-        .disposed(by: self.disposeBag)
+        scrollAction.delay(RxTimeInterval(0.1))
+                    .drive(onNext: { action in
+                        switch action {
+                        case .toTop:
+                            self.tableView.scrollToRow(at: IndexPath(row: 0, section: 0), at: .none, animated: true)
+                        }
+                    })
+                    .disposed(by: self.disposeBag)
     }
 
     var tableViewScrollEnabled: AnyObserver<Bool> {

--- a/lockbox-iosTests/ItemListPresenterSpec.swift
+++ b/lockbox-iosTests/ItemListPresenterSpec.swift
@@ -19,10 +19,12 @@ class ItemListPresenterSpec: QuickSpec {
         var sortButtonEnableObserver: TestableObserver<Bool>!
         var tableViewScrollObserver: TestableObserver<Bool>!
         var sortingButtonTitleObserver: TestableObserver<String>!
+        var scrollActionObserver: TestableObserver<ScrollAction>!
         var dismissSpinnerObserver: TestableObserver<Void>!
         let disposeBag = DisposeBag()
         var dismissKeyboardCalled = false
         var displaySpinnerCalled = false
+        var scrollToTopCalled = false
         var pullToRefreshObserver: TestableObserver<Bool>!
         var fakeOnSettingsPressed = PublishSubject<Void>()
         var fakeOnSortingButtonPressed = PublishSubject<Void>()
@@ -36,6 +38,11 @@ class ItemListPresenterSpec: QuickSpec {
 
         func bind(sortingButtonTitle: Driver<String>) {
             sortingButtonTitle.drive(sortingButtonTitleObserver).disposed(by: self.disposeBag)
+        }
+        
+        func bind(scrollAction: Driver<ScrollAction>) {
+            scrollToTopCalled = true
+            scrollAction.drive(scrollActionObserver).disposed(by: self.disposeBag)
         }
 
         func displayAlertController(buttons: [AlertActionButtonConfiguration], title: String?, message: String?, style: UIAlertController.Style) {
@@ -72,10 +79,16 @@ class ItemListPresenterSpec: QuickSpec {
             return ControlEvent<Void>(events: fakeOnSortingButtonPressed.asObservable())
         }
     }
-
+    
+    
     class FakeDispatcher: Dispatcher {
         var dispatchedActions: [Action] = []
-
+        let fakeRegistration = PublishSubject<Action>()
+        
+        override var register: Observable<Action> {
+            return self.fakeRegistration.asObservable()
+        }
+        
         override func dispatch(action: Action) {
             self.dispatchedActions.append(action)
         }
@@ -143,6 +156,7 @@ class ItemListPresenterSpec: QuickSpec {
                 self.userDefaultStore = FakeUserDefaultStore()
                 self.view.itemsObserver = self.scheduler.createObserver([ItemSectionModel].self)
                 self.view.sortingButtonTitleObserver = self.scheduler.createObserver(String.self)
+                self.view.scrollActionObserver = self.scheduler.createObserver(ScrollAction.self)
                 self.view.sortButtonEnableObserver = self.scheduler.createObserver(Bool.self)
                 self.view.tableViewScrollObserver = self.scheduler.createObserver(Bool.self)
                 self.view.dismissSpinnerObserver = self.scheduler.createObserver(Void.self)
@@ -564,7 +578,15 @@ class ItemListPresenterSpec: QuickSpec {
             describe("sortingButton") {
                 beforeEach {
                     self.subject.onViewReady()
+                    
+                    let itemSettingObservable: TestableObservable<ScrollAction> = self.scheduler.createColdObservable([next(50, ScrollAction.toTop)])
+                    itemSettingObservable
+                        .bind(to: self.view.scrollActionObserver)
+                        .disposed(by: self.disposeBag)
+                    
                     self.view.fakeOnSortingButtonPressed.onNext(())
+                    
+                    self.scheduler.start()
                     self.userDefaultStore.itemListSortStub.onNext(Setting.ItemListSort.alphabetically)
                 }
 
@@ -587,6 +609,18 @@ class ItemListPresenterSpec: QuickSpec {
                         expect(action).notTo(beNil())
                         expect(action).to(equal(SettingAction.itemListSort(sort: Setting.ItemListSort.alphabetically)))
                     }
+                    
+                    it("dispatches the scroll to top action. ScrollAction") {
+                        let dispatched = self.dispatcher.dispatchedActions.dropLast()
+                        let action = dispatched.last as? ScrollAction
+                        expect(action).notTo(beNil())
+                        expect(action).to(equal(ScrollAction.toTop))
+                    }
+                    
+                    it("scrolls to top") {
+                        expect(self.view.scrollActionObserver.events.count).to(equal(1))
+                        expect(self.view.scrollToTopCalled).to(beTrue())
+                    }
                 }
 
                 describe("tapping recently used") {
@@ -598,6 +632,18 @@ class ItemListPresenterSpec: QuickSpec {
                         let action = self.dispatcher.dispatchedActions.last as? SettingAction
                         expect(action).notTo(beNil())
                         expect(action).to(equal(SettingAction.itemListSort(sort: Setting.ItemListSort.recentlyUsed)))
+                    }
+                    
+                    it("dispatches the scroll to top action. ScrollAction") {
+                        let dispatched = self.dispatcher.dispatchedActions.dropLast()
+                        let action = dispatched.last as? ScrollAction
+                        expect(action).notTo(beNil())
+                        expect(action).to(equal(ScrollAction.toTop))
+                    }
+                    
+                    it("scrolls to top") {
+                        expect(self.view.scrollActionObserver.events.count).to(equal(1))
+                        expect(self.view.scrollToTopCalled).to(beTrue())
                     }
                 }
             }

--- a/lockbox-iosTests/ItemListPresenterSpec.swift
+++ b/lockbox-iosTests/ItemListPresenterSpec.swift
@@ -80,7 +80,6 @@ class ItemListPresenterSpec: QuickSpec {
         }
     }
     
-    
     class FakeDispatcher: Dispatcher {
         var dispatchedActions: [Action] = []
         let fakeRegistration = PublishSubject<Action>()

--- a/lockbox-iosTests/ItemListViewSpec.swift
+++ b/lockbox-iosTests/ItemListViewSpec.swift
@@ -25,6 +25,7 @@ class ItemListViewSpec: QuickSpec {
         var fakeFilterTextObserver: TestableObserver<String>!
         var fakeCancelObserver: TestableObserver<Void>!
         var fakeEditEndedObserver: TestableObserver<Void>!
+        var fakeListSortedObserver: TestableObserver<Setting.ItemListSort>!
 
         override func onViewReady() {
             onViewReadyCalled = true
@@ -45,6 +46,10 @@ class ItemListViewSpec: QuickSpec {
         override var editEndedObserver: AnyObserver<Void> {
             return self.fakeEditEndedObserver.asObserver()
         }
+        
+        override var listSortedObserver: AnyObserver<Setting.ItemListSort> {
+            return self.fakeListSortedObserver.asObserver()
+        }
     }
 
     private var presenter: FakeItemListPresenter!
@@ -63,6 +68,7 @@ class ItemListViewSpec: QuickSpec {
                 self.presenter.fakeFilterTextObserver = self.scheduler.createObserver(String.self)
                 self.presenter.fakeCancelObserver = self.scheduler.createObserver(Void.self)
                 self.presenter.fakeEditEndedObserver = self.scheduler.createObserver(Void.self)
+                self.presenter.fakeListSortedObserver = self.scheduler.createObserver(Setting.ItemListSort.self)
                 self.subject.basePresenter = self.presenter
 
                 _ = UINavigationController(rootViewController: self.subject)


### PR DESCRIPTION
Closes https://github.com/mozilla-lockbox/lockbox-ios/issues/439

Automatically scrolls the `tableView` in `ItemsListView` to the top after a new sort has been performed.

Sends a `ScrollAction` when the sort order is changed and then to performs the scroll to top when the `ScrollAction` is received. 

It feels like overkill, but this was the only way I could find that would ensure that the table data update had occurred before the scroll to top was performed. If the scroll to top is performed before the table data update is complete, then the top of the table changes after the scroll to top completes and so the table is not actually at the top! 

Actually, there is another way. It involved adding a very small delay (0.1secs) to the observer before the `scrollToTop` call was made. You can see this in Part 1. In all conscience I could not submit a PR where the solution was to add a random timing delay to make something work so I had to find another way. This was it. 

P.S. I know this needs tests. Still trying to figure out how to add them....