### PR TITLE
XCUITests refactor to run tests independently

### DIFF
--- a/LockboxXCUITests/LockBoxScreenGraph.swift
+++ b/LockboxXCUITests/LockBoxScreenGraph.swift
@@ -22,6 +22,8 @@ let springboard = XCUIApplication(bundleIdentifier: "com.apple.springboard")
 let settings = XCUIApplication(bundleIdentifier: "com.apple.Preferences")
 let safari = XCUIApplication(bundleIdentifier: "com.apple.mobilesafari")
 
+let appName = "Lockbox"
+
 class Screen {
     static let WelcomeScreen = "WelcomeScreen"
     static let OnboardingWelcomeScreen = "OnboardingWelcomeScreen"
@@ -38,7 +40,7 @@ class Screen {
     static let LockedScreen = "LockedScreen"
     static let AccountSettingsMenu = "AccountSettingsMenu"
     static let AutolockSettingsMenu = "AutolockSettingsMenu"
-    static let AutoFillPasswordSetUpInstructionsSettings = "AutoFillPasswordSetUpInstructionsSettings"
+    static let AutoFillSetUpInstructionsSettings = "AutoFillSetUpInstructionsSettings"
 
     static let SortEntriesMenu = "SortEntriesMenu"
 
@@ -174,7 +176,7 @@ func createScreenGraph(for test: XCTestCase, with app: XCUIApplication) -> MMScr
         screenState.tap(app.tables.cells["openWebSitesInSettingOption"], to: Screen.OpenSitesInMenu)
         screenState.tap(app.tables.cells["accountSettingOption"], to: Screen.AccountSettingsMenu)
         screenState.tap(app.tables.cells["autoLockSettingOption"], to: Screen.AutolockSettingsMenu)
-        screenState.tap(app.tables.cells["autoFillSettingsOption"], to: Screen.AutoFillPasswordSetUpInstructionsSettings)
+        screenState.tap(app.tables.cells["autoFillSettingsOption"], to: Screen.AutoFillSetUpInstructionsSettings)
 
         screenState.gesture(forAction: Action.SendUsageData) { userState in
             app.switches["sendUsageData.switch"].tap()
@@ -204,7 +206,7 @@ func createScreenGraph(for test: XCTestCase, with app: XCUIApplication) -> MMScr
         }
     }
 
-    map.addScreenState(Screen.AutoFillPasswordSetUpInstructionsSettings) { screenState in
+    map.addScreenState(Screen.AutoFillSetUpInstructionsSettings) { screenState in
         screenState.tap(app.buttons["gotIt.button"], to: Screen.SettingsMenu)
     }
 
@@ -246,9 +248,14 @@ extension BaseTestCase {
         if #available(iOS 12.0, *) {
             waitforExistence(app.buttons["setupAutofill.button"])
             if (app.buttons["setupAutofill.button"].exists) {
-            app.buttons["notNow.button"].tap()
+                app.buttons["notNow.button"].tap()
             }
         }
+    }
+
+    func tapOnAutofillConfiguration() {
+        waitforExistence(app.buttons["setupAutofill.button"])
+        app.buttons["setupAutofill.button"].tap()
     }
 
     func tapOnFinishButton() {
@@ -374,7 +381,7 @@ extension BaseTestCase {
 
     func deleteApp(name: String) {
         app.terminate()
-        let icon = springboard.icons["Lockbox"]
+        let icon = springboard.icons[appName]
         if icon.exists {
             let iconFrame = icon.frame
             let springboardFrame = springboard.frame

--- a/LockboxXCUITests/LockBoxScreenGraph.swift
+++ b/LockboxXCUITests/LockBoxScreenGraph.swift
@@ -220,19 +220,6 @@ func createScreenGraph(for test: XCTestCase, with app: XCUIApplication) -> MMScr
 
 extension BaseTestCase {
 
-   func disconnectAndConnectAccount() {
-        navigator.performAction(Action.DisconnectFirefoxLockbox)
-        // And, connect it again
-        waitforExistence(app.buttons["getStarted.button"])
-        app.buttons["getStarted.button"].tap()
-        userState.fxaUsername =  emailTestAccountLogins
-        userState.fxaPassword = passwordTestAccountLogins
-        waitforExistence(app.webViews.textFields["Email"], timeout: 10)
-        navigator.nowAt(Screen.FxASigninScreenEmail)
-        navigator.performAction(Action.FxATypeEmail)
-        navigator.performAction(Action.FxATypePassword)
-    }
-
     func loginFxAccount() {
         userState.fxaPassword = passwordTestAccountLogins
         userState.fxaUsername = "test-b62feb2ed6@restmail.net"
@@ -246,7 +233,8 @@ extension BaseTestCase {
 
     func skipAutofillConfiguration() {
         if #available(iOS 12.0, *) {
-            waitforExistence(app.buttons["setupAutofill.button"])
+            //If autofill is set this option will not appear
+            sleep(3)
             if (app.buttons["setupAutofill.button"].exists) {
                 app.buttons["notNow.button"].tap()
             }

--- a/LockboxXCUITests/LockboxXCUITests.swift
+++ b/LockboxXCUITests/LockboxXCUITests.swift
@@ -86,7 +86,7 @@ class LockboxXCUITests: BaseTestCase {
         waitforExistence(app.navigationBars["accountSetting.navigationBar"])
         XCTAssertTrue(app.staticTexts["username.Label"].exists)
         XCTAssertEqual(app.staticTexts["username.Label"].label, emailTestAccountLogins)
-        XCTAssertTrue(app.buttons["disconnectFirefoxLockbox.button"].exists, "The option to disconnect does not appear")
+        XCTAssertTrue(app.buttons["disconnectAndConnectAccountFirefoxLockbox.button"].exists, "The option to disconnect does not appear")
 
         // Try Cancel disconnecting the account
         navigator.performAction(Action.DisconnectFirefoxLockboxCancel)

--- a/LockboxXCUITests/LockboxXCUITests.swift
+++ b/LockboxXCUITests/LockboxXCUITests.swift
@@ -86,10 +86,15 @@ class LockboxXCUITests: BaseTestCase {
         waitforExistence(app.navigationBars["accountSetting.navigationBar"])
         XCTAssertTrue(app.staticTexts["username.Label"].exists)
         XCTAssertEqual(app.staticTexts["username.Label"].label, emailTestAccountLogins)
-        XCTAssertTrue(app.buttons["disconnectAndConnectAccountFirefoxLockbox.button"].exists, "The option to disconnect does not appear")
+        XCTAssertTrue(app.buttons["disconnectFirefoxLockbox.button"].exists, "The option to disconnect does not appear")
 
         // Try Cancel disconnecting the account
         navigator.performAction(Action.DisconnectFirefoxLockboxCancel)
+        waitforExistence(app.buttons["disconnectFirefoxLockbox.button"])
+
+        // Disconnect the account
+        navigator.performAction(Action.DisconnectFirefoxLockbox)
+        waitforExistence(app.buttons["getStarted.button"])
     }
 
     func testSettings() {


### PR DESCRIPTION
Connected to #531 

This PR is to try a new approach to run the tests independently so that one failure in one test does not affect the other tests. 
All the previous checks done in the tests are still in place but running in different tests, grouping each one per feature/menu.
Also, this approach, at least locally, seems to save time when executing the tests. Hopefully it will be the same on BB.

