### PR TITLE
759-xcuitests-new-setup-autofill-screen

### DIFF
--- a/LockboxXCUITests/LockBoxScreenGraph.swift
+++ b/LockboxXCUITests/LockBoxScreenGraph.swift
@@ -8,6 +8,9 @@ import XCTest
 
 class Screen {
     static let WelcomeScreen = "WelcomeScreen"
+    static let OnboardingWelcomeScreen = "OnboardingWelcomeScreen"
+    static let AutofillOnboardingWhenLogingIn = "AutofillOnboardingWhenLogingIn"
+    static let AutofillSetUpInstructionsWhenLogingIn = "AutofillSetUpInstructionsWhenLogingIn"
     static let LockboxMainPage = "LockboxMainPage"
     static let SettingsMenu = "SettingsMenu"
 
@@ -19,6 +22,7 @@ class Screen {
     static let LockedScreen = "LockedScreen"
     static let AccountSettingsMenu = "AccountSettingsMenu"
     static let AutolockSettingsMenu = "AutolockSettingsMenu"
+    static let AutoFillPasswordSetUpInstructionsSettings = "AutoFillPasswordSetUpInstructionsSettings"
 
     static let SortEntriesMenu = "SortEntriesMenu"
 
@@ -31,7 +35,9 @@ class Action {
     static let FxATapOnSignInButton = "FxATapOnSignInButton"
     static let FxALogInSuccessfully = "FxALogInSuccessfully"
 
-    static let OpenSettingsMenu = "OpenSettingsMenu"
+    static let NotAutofillSetUpNow = "NotAutofillSetUpNow"
+    static let SetAutofillNow = "SetAutofillNow"
+    static let TapOnFinish = "TapOnFinish"
 
     static let LockNow = "LockNow"
     static let SendUsageData = "SendUsageData"
@@ -88,13 +94,31 @@ func createScreenGraph(for test: XCTestCase, with app: XCUIApplication) -> MMScr
     }
 
     map.addScreenState(Screen.FxASigninScreenPassword) { screenState in
-        screenState.gesture(forAction: Action.FxATypePassword) { userState in
+        screenState.gesture(forAction: Action.FxATypePassword, transitionTo: Screen.AutofillOnboardingWhenLogingIn) { userState in
             app.webViews.secureTextFields["Password"].tap()
             app.webViews.secureTextFields["Password"].typeText(userState.fxaPassword!)
             app.webViews.buttons["Sign in"].tap()
         }
     }
 
+    map.addScreenState(Screen.OnboardingWelcomeScreen) { screenState in
+        screenState.gesture(forAction: Action.TapOnFinish, transitionTo: Screen.LockboxMainPage) { userState in
+            app.buttons["finish.button"].tap()
+        }
+    }
+
+    map.addScreenState(Screen.AutofillOnboardingWhenLogingIn) { screenState in
+        screenState.gesture(forAction: Action.NotAutofillSetUpNow, transitionTo: Screen.OnboardingWelcomeScreen) { userState in
+            app.buttons["notNow.button"].tap()
+        }
+        screenState.gesture(forAction: Action.SetAutofillNow, transitionTo: Screen.AutofillSetUpInstructionsWhenLogingIn) { userState in
+            app.buttons["setupAutofill.button"].tap()
+        }
+    }
+
+    map.addScreenState(Screen.AutofillSetUpInstructionsWhenLogingIn) { screenState in
+        screenState.tap(app.buttons["gotIt.button"], to: Screen.LockboxMainPage)
+    }
 
     map.addScreenState(Screen.FxCreateAccount) { screenState in
         screenState.backAction = navigationControllerBackAction
@@ -134,14 +158,10 @@ func createScreenGraph(for test: XCTestCase, with app: XCUIApplication) -> MMScr
         screenState.tap(app.tables.cells["openWebSitesInSettingOption"], to: Screen.OpenSitesInMenu)
         screenState.tap(app.tables.cells["accountSettingOption"], to: Screen.AccountSettingsMenu)
         screenState.tap(app.tables.cells["autoLockSettingOption"], to: Screen.AutolockSettingsMenu)
+        screenState.tap(app.tables.cells["autoFillSettingsOption"], to: Screen.AutoFillPasswordSetUpInstructionsSettings)
 
         screenState.gesture(forAction: Action.SendUsageData) { userState in
             app.switches["sendUsageData.switch"].tap()
-        }
-
-        screenState.gesture(forAction: Action.OpenDeviceSettings) { userState in
-            app.cells["autoFillSettingsOption"].tap()
-
         }
 
         screenState.gesture(forAction: Action.LockNow) { userState in
@@ -166,6 +186,10 @@ func createScreenGraph(for test: XCTestCase, with app: XCUIApplication) -> MMScr
             app.buttons["disconnectFirefoxLockbox.button"].tap()
             app.buttons["Cancel"].tap()
         }
+    }
+
+    map.addScreenState(Screen.AutoFillPasswordSetUpInstructionsSettings) { screenState in
+        screenState.tap(app.buttons["gotIt.button"], to: Screen.SettingsMenu)
     }
 
     map.addScreenState(Screen.AutolockSettingsMenu) { screenState in

--- a/LockboxXCUITests/LockBoxScreenGraph.swift
+++ b/LockboxXCUITests/LockBoxScreenGraph.swift
@@ -117,7 +117,7 @@ func createScreenGraph(for test: XCTestCase, with app: XCUIApplication) -> MMScr
     }
 
     map.addScreenState(Screen.AutofillSetUpInstructionsWhenLogingIn) { screenState in
-        screenState.tap(app.buttons["gotIt.button"], to: Screen.LockboxMainPage)
+        screenState.tap(app.buttons["gotIt.button"], to: Screen.OnboardingWelcomeScreen)
     }
 
     map.addScreenState(Screen.FxCreateAccount) { screenState in

--- a/LockboxXCUITests/LockboxXCUITests.swift
+++ b/LockboxXCUITests/LockboxXCUITests.swift
@@ -256,19 +256,26 @@ class LockboxXCUITests: BaseTestCase {
         disconnectAndConnectAccount()
         if #available(iOS 12.0, *) {
             waitforExistence(app.buttons["setupAutofill.button"])
-            app.buttons["setupAutofill.button"].tap()
+            navigator.performAction(Action.SetAutofillNow)
+            waitforExistence(app.buttons["gotIt.button"])
+            navigator.goto(Screen.LockboxMainPage)
+            waitforExistence(app.navigationBars["firefoxLockbox.navigationBar"])
+        } else {
+            waitforExistence(app.navigationBars["firefoxLockbox.navigationBar"])
         }
-        let settingsApp = XCUIApplication(bundleIdentifier: "com.apple.Preferences")
-        waitforExistence(settingsApp.cells.staticTexts["Passwords & Accounts"])
     }
 
     // Once app is open
     func testSetAutofillSettings() {
-        // Open Setting to add Lockbox
+        // Open Lockbox settings to check the Autofill option
+        navigator.goto(Screen.AutoFillPasswordSetUpInstructionsSettings)
+        XCTAssertTrue(app.buttons["gotIt.button"].exists)
         navigator.goto(Screen.SettingsMenu)
-        navigator.performAction(Action.OpenDeviceSettings)
-        // Wait until settings app is open
+        waitforExistence(app.navigationBars["settings.navigationBar"])
+
+        // Then open settings app to follow the described steps
         let settingsApp = XCUIApplication(bundleIdentifier: "com.apple.Preferences")
+        settingsApp.launch()
         waitforExistence(settingsApp.cells.staticTexts["Passwords & Accounts"])
         // Configure Passwords & Accounts settings
         settingsApp.cells.staticTexts["Passwords & Accounts"].tap()

--- a/LockboxXCUITests/LockboxXCUITests.swift
+++ b/LockboxXCUITests/LockboxXCUITests.swift
@@ -48,10 +48,10 @@ class LockboxXCUITests: BaseTestCase {
 
         if #available(iOS 12.0, *) {
             waitforExistence(app.buttons["setupAutofill.button"])
-            app.buttons["notNow.button"].tap()
+            navigator.performAction(Action.NotAutofillSetUpNow)
         }
         waitforExistence(app.buttons["finish.button"])
-        app.buttons["finish.button"].tap()
+        navigator.goto(Screen.LockboxMainPage)
 
         waitforExistence(app.tables.cells.staticTexts[firstEntryEmail], timeout: 15)
 
@@ -259,8 +259,6 @@ class LockboxXCUITests: BaseTestCase {
             navigator.performAction(Action.SetAutofillNow)
             waitforExistence(app.buttons["gotIt.button"])
             navigator.goto(Screen.LockboxMainPage)
-            waitforExistence(app.navigationBars["firefoxLockbox.navigationBar"])
-        } else {
             waitforExistence(app.navigationBars["firefoxLockbox.navigationBar"])
         }
     }

--- a/lockbox-ios/Storyboard/SetupAutofill.storyboard
+++ b/lockbox-ios/Storyboard/SetupAutofill.storyboard
@@ -29,6 +29,7 @@
                                     <userDefinedRuntimeAttribute type="number" keyPath="layer.cornerRadius">
                                         <integer key="value" value="4"/>
                                     </userDefinedRuntimeAttribute>
+                                    <userDefinedRuntimeAttribute type="string" keyPath="accessibilityIdentifier" value="gotIt.button"/>
                                 </userDefinedRuntimeAttributes>
                             </button>
                             <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="autofill-step-icons" translatesAutoresizingMaskIntoConstraints="NO" id="3Mq-xu-nQh">


### PR DESCRIPTION
Fixes #759 

Due to the new screen implemented tests need to be updated.
This PR adds this screen to the ScreenGraph and previous screens that were missing there. As well as the actions needed to go interact with those screens.