### PR TITLE
SettingsListView: move done btn tap binding to presenter

### DIFF
--- a/lockbox-ios/Presenter/SettingListPresenter.swift
+++ b/lockbox-ios/Presenter/SettingListPresenter.swift
@@ -11,6 +11,7 @@ import LocalAuthentication
 protocol SettingListViewProtocol: class, AlertControllerView {
     func bind(items: Driver<[SettingSectionModel]>)
     var onLockNow: ControlEvent<Void> { get }
+    var onDoneButtonPressed: ControlEvent<Void>? { get }
 }
 
 class SettingListPresenter {
@@ -19,12 +20,6 @@ class SettingListPresenter {
     private let userDefaultStore: UserDefaultStore
     private let biometryManager: BiometryManager
     private let disposeBag = DisposeBag()
-
-    lazy private(set) var onDone: AnyObserver<Void> = {
-        return Binder(self) { target, _ in
-            target.dispatcher.dispatch(action: MainRouteAction.list)
-        }.asObserver()
-    }()
 
     lazy private(set) var onSettingCellTapped: AnyObserver<RouteAction?> = {
         return Binder(self) { target, action in
@@ -128,6 +123,13 @@ class SettingListPresenter {
                     }
                 }
                 .disposed(by: self.disposeBag)
+        
+        if let onDoneButtonPressed = self.view?.onDoneButtonPressed {
+            onDoneButtonPressed.subscribe { _ in
+                self.dispatcher.dispatch(action: MainRouteAction.list)
+            }
+            .disposed(by: self.disposeBag)
+        }
     }
 }
 

--- a/lockbox-ios/View/SettingListView.swift
+++ b/lockbox-ios/View/SettingListView.swift
@@ -27,6 +27,7 @@ class SettingListView: UIViewController {
         self.setupDataSource()
         self.setupDelegate()
         self.setupLockNowButton()
+        self.setupNavbar()
         self.presenter?.onViewReady()
 
         // Subscribe to Dynamic Type change events.
@@ -43,7 +44,6 @@ class SettingListView: UIViewController {
 
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
-        self.setupNavbar()
         self.styleTableViewBackground()
     }
 
@@ -63,6 +63,10 @@ extension SettingListView: SettingListViewProtocol {
             items.drive(self.tableView.rx.items(dataSource: dataSource))
                     .disposed(by: self.disposeBag)
         }
+    }
+    
+    var onDoneButtonPressed: ControlEvent<Void>? {
+        return self.navigationItem.rightBarButtonItem?.rx.tap
     }
 }
 
@@ -144,11 +148,6 @@ extension SettingListView {
             .font: UIFont.navigationButtonFont
         ], for: .normal)
 
-        if let presenter = presenter {
-            navigationItem.rightBarButtonItem?.rx.tap
-                    .bind(to: presenter.onDone)
-                    .disposed(by: self.disposeBag)
-        }
     }
 
     fileprivate func setupLockNowButton() {

--- a/lockbox-iosTests/SettingListPresenterSpec.swift
+++ b/lockbox-iosTests/SettingListPresenterSpec.swift
@@ -16,6 +16,7 @@ class SettingListPresenterSpec: QuickSpec {
 
         var displayAlertControllerCalled = false
         var displayAlertControllerButtons: [AlertActionButtonConfiguration]?
+        var fakeOnDoneButtonPressed = PublishSubject<Void>()
         func displayAlertController(buttons: [AlertActionButtonConfiguration], title: String?, message: String?, style: UIAlertController.Style) {
             displayAlertControllerCalled = true
             displayAlertControllerButtons = buttons
@@ -32,6 +33,10 @@ class SettingListPresenterSpec: QuickSpec {
 
         var onLockNow: ControlEvent<Void> {
             return ControlEvent(events: fakeButtonPress.asObservable())
+        }
+        
+        var onDoneButtonPressed: ControlEvent<Void>? {
+            return ControlEvent<Void>(events: fakeOnDoneButtonPressed.asObservable())
         }
     }
 
@@ -207,13 +212,8 @@ class SettingListPresenterSpec: QuickSpec {
 
             describe("onDone") {
                 beforeEach {
-                    let voidObservable = self.scheduler.createColdObservable([next(50, ())])
-
-                    voidObservable
-                            .bind(to: self.subject.onDone)
-                            .disposed(by: self.disposeBag)
-
-                    self.scheduler.start()
+                    self.subject.onViewReady()
+                    self.view.fakeOnDoneButtonPressed.onNext(())
                 }
 
                 it("invokes the main list action") {

--- a/lockbox-iosTests/SettingListViewSpec.swift
+++ b/lockbox-iosTests/SettingListViewSpec.swift
@@ -166,5 +166,25 @@ class SettingListViewSpec: QuickSpec {
                 }
             }
         }
+        
+        describe("tapping the done button") {
+            var buttonObserver = self.scheduler.createObserver(Void.self)
+            
+            beforeEach {
+                buttonObserver = self.scheduler.createObserver(Void.self)
+                
+                self.subject.onDoneButtonPressed!
+                    .subscribe(buttonObserver)
+                    .disposed(by: self.disposeBag)
+                
+                let doneButton = self.subject.navigationItem.rightBarButtonItem!
+                let _ = doneButton.target?.perform(doneButton.action)
+            }
+            
+            it("tells observers about button taps") {
+                expect(buttonObserver.events.count).to(be(1))
+            }
+        }
+        
     }
 }

--- a/lockbox-iosTests/SettingListViewSpec.swift
+++ b/lockbox-iosTests/SettingListViewSpec.swift
@@ -23,12 +23,6 @@ class SettingListViewSpec: QuickSpec {
             onViewReadyCalled = true
         }
 
-        override var onDone: AnyObserver<Void> {
-            return Binder(self) { target, _ in
-                target.onDoneActionDispatched = true
-            }.asObserver()
-        }
-
         override var onSettingCellTapped: AnyObserver<RouteAction?> {
             return self.settingCellStub.asObserver()
         }


### PR DESCRIPTION
Connected to #209

Very similar to #762

In addition, I moved the call to set up the navbar from viewDidAppear() to viewDidLoad() so that the button was configured/available to bind before the presenter's onViewReady was called.. if thats an issue or sub-optimal, let me know. 

I didn't address the [tableView cells' selection bindings](https://github.com/mozilla-lockbox/lockbox-ios/blob/9566b2f5e7de8fc42a3df7777de0c094ea18abe3/lockbox-ios/View/SettingListView.swift#L114-L121).. didn't know if those were something you all wanted moved as well, but happy to address those too if that's the case! 

