### PR TITLE
[#209] Move btn bindings to presenter

### DIFF
--- a/lockbox-ios/Presenter/AccountSettingPresenter.swift
+++ b/lockbox-ios/Presenter/AccountSettingPresenter.swift
@@ -9,12 +9,14 @@ import RxSwift
 protocol AccountSettingViewProtocol: class, AlertControllerView {
     func bind(avatarImage: Driver<Data>)
     func bind(displayName: Driver<String>)
+    var unLinkAccountButtonPressed: ControlEvent<Void> { get }
 }
 
 class AccountSettingPresenter {
     weak var view: AccountSettingViewProtocol?
     let dispatcher: Dispatcher
     let accountStore: AccountStore
+    private let disposeBag = DisposeBag()
 
     lazy private var unlinkAccountObserver: AnyObserver<Void> = {
         return Binder(self) { target, _ in
@@ -27,21 +29,6 @@ class AccountSettingPresenter {
     lazy private(set) var onSettingsTap: AnyObserver<Void> = {
         return Binder(self) { target, _ in
             target.dispatcher.dispatch(action: SettingRouteAction.list)
-        }.asObserver()
-    }()
-
-    lazy private(set) var unLinkAccountTapped: AnyObserver<Void> = {
-        return Binder(self) { target, _ in
-            target.view?.displayAlertController(buttons: [
-                AlertActionButtonConfiguration(title: Constant.string.cancel,
-                                               tapObserver: nil,
-                                               style: .cancel),
-                AlertActionButtonConfiguration(title: Constant.string.unlink,
-                        tapObserver: target.unlinkAccountObserver,
-                        style: .destructive)],
-                    title: Constant.string.confirmDialogTitle,
-                    message: Constant.string.confirmDialogMessage,
-                    style: .alert)
         }.asObserver()
     }()
 
@@ -77,5 +64,24 @@ class AccountSettingPresenter {
                 .filterNil()
 
         self.view?.bind(avatarImage: avatarImageDriver)
+        
+        self.view?.unLinkAccountButtonPressed.subscribe { [weak self] _ in
+            self?.view?.displayAlertController(
+                buttons: [
+                    AlertActionButtonConfiguration(
+                        title: Constant.string.cancel,
+                        tapObserver: nil,
+                        style: .cancel
+                    ),
+                    AlertActionButtonConfiguration(
+                        title: Constant.string.unlink,
+                        tapObserver: self?.unlinkAccountObserver,
+                        style: .destructive)
+                ],
+                title: Constant.string.confirmDialogTitle,
+                message: Constant.string.confirmDialogMessage,
+                style: .alert)
+        }
+        .disposed(by: self.disposeBag)
     }
 }

--- a/lockbox-ios/Presenter/AccountSettingPresenter.swift
+++ b/lockbox-ios/Presenter/AccountSettingPresenter.swift
@@ -10,6 +10,7 @@ protocol AccountSettingViewProtocol: class, AlertControllerView {
     func bind(avatarImage: Driver<Data>)
     func bind(displayName: Driver<String>)
     var unLinkAccountButtonPressed: ControlEvent<Void> { get }
+    var onSettingsButtonPressed: ControlEvent<Void>? { get }
 }
 
 class AccountSettingPresenter {
@@ -64,6 +65,13 @@ class AccountSettingPresenter {
                 .filterNil()
 
         self.view?.bind(avatarImage: avatarImageDriver)
+        
+        if let onSettingsButtonPressed = self.view?.onSettingsButtonPressed {
+            onSettingsButtonPressed.subscribe { [weak self] _ in
+                self?.dispatcher.dispatch(action: SettingRouteAction.list)
+            }
+            .disposed(by: disposeBag)
+        }
         
         self.view?.unLinkAccountButtonPressed.subscribe { [weak self] _ in
             self?.view?.displayAlertController(

--- a/lockbox-ios/View/AccountSettingView.swift
+++ b/lockbox-ios/View/AccountSettingView.swift
@@ -48,17 +48,16 @@ extension AccountSettingView: AccountSettingViewProtocol {
                 .drive(self.usernameLabel.rx.text)
                 .disposed(by: self.disposeBag)
     }
+    
+    var unLinkAccountButtonPressed: ControlEvent<Void> {
+        return self.unlinkAccountButton.rx.tap
+    }
+    
 }
 
 extension AccountSettingView: UIGestureRecognizerDelegate {
     fileprivate func setupUnlinkAccountButton() {
         self.unlinkAccountButton.setBorder(color: Constant.color.cellBorderGrey, width: 0.5)
-
-        if let presenter = self.presenter {
-            self.unlinkAccountButton.rx.tap
-                    .bind(to: presenter.unLinkAccountTapped)
-                    .disposed(by: self.disposeBag)
-        }
     }
 
     fileprivate func setupNavBar() {

--- a/lockbox-ios/View/AccountSettingView.swift
+++ b/lockbox-ios/View/AccountSettingView.swift
@@ -53,6 +53,14 @@ extension AccountSettingView: AccountSettingViewProtocol {
         return self.unlinkAccountButton.rx.tap
     }
     
+    var onSettingsButtonPressed: ControlEvent<Void>? {
+        if let button = self.navigationItem.leftBarButtonItem?.customView as? UIButton {
+            return button.rx.tap
+        }
+        
+        return nil
+    }
+    
 }
 
 extension AccountSettingView: UIGestureRecognizerDelegate {
@@ -72,10 +80,6 @@ extension AccountSettingView: UIGestureRecognizerDelegate {
         self.navigationItem.leftBarButtonItem = UIBarButtonItem(customView: leftButton)
 
         if let presenter = self.presenter {
-            leftButton.rx.tap
-                .bind(to: presenter.onSettingsTap)
-                .disposed(by: self.disposeBag)
-
             self.navigationController?.interactivePopGestureRecognizer?.delegate = self
             self.navigationController?.interactivePopGestureRecognizer?.rx.event
                 .map { _ -> Void in

--- a/lockbox-iosTests/AccountSettingPresenterSpec.swift
+++ b/lockbox-iosTests/AccountSettingPresenterSpec.swift
@@ -20,6 +20,7 @@ class AccountSettingPresenterSpec: QuickSpec {
         var displayAlertControllerTitle: String?
         var displayAlertControllerMessage: String?
         var fakeUnlinkAccountButtonPressed = PublishSubject<Void>()
+        var fakeOnSettingsButtonPressed = PublishSubject<Void>()
 
         let disposeBag = DisposeBag()
 
@@ -39,6 +40,10 @@ class AccountSettingPresenterSpec: QuickSpec {
         
         var unLinkAccountButtonPressed: ControlEvent<Void> {
             return ControlEvent<Void>(events: fakeUnlinkAccountButtonPressed.asObservable())
+        }
+        
+        var onSettingsButtonPressed: ControlEvent<Void>? {
+            return ControlEvent<Void>(events: fakeOnSettingsButtonPressed.asObservable())
         }
     }
 
@@ -128,13 +133,8 @@ class AccountSettingPresenterSpec: QuickSpec {
 
             describe("onSettingsTap") {
                 beforeEach {
-                    let voidObservable = self.scheduler.createColdObservable([next(50, ())])
-
-                    voidObservable
-                            .bind(to: self.subject.onSettingsTap)
-                            .disposed(by: self.disposeBag)
-
-                    self.scheduler.start()
+                    self.subject.onViewReady()
+                    self.view.fakeOnSettingsButtonPressed.onNext(()) 
                 }
 
                 it("sends the settings list action") {

--- a/lockbox-iosTests/AccountSettingPresenterSpec.swift
+++ b/lockbox-iosTests/AccountSettingPresenterSpec.swift
@@ -19,6 +19,7 @@ class AccountSettingPresenterSpec: QuickSpec {
         var displayAlertActionButtons: [AlertActionButtonConfiguration]?
         var displayAlertControllerTitle: String?
         var displayAlertControllerMessage: String?
+        var fakeUnlinkAccountButtonPressed = PublishSubject<Void>()
 
         let disposeBag = DisposeBag()
 
@@ -34,6 +35,10 @@ class AccountSettingPresenterSpec: QuickSpec {
             self.displayAlertActionButtons = buttons
             self.displayAlertControllerMessage = message
             self.displayAlertControllerTitle = title
+        }
+        
+        var unLinkAccountButtonPressed: ControlEvent<Void> {
+            return ControlEvent<Void>(events: fakeUnlinkAccountButtonPressed.asObservable())
         }
     }
 
@@ -94,12 +99,8 @@ class AccountSettingPresenterSpec: QuickSpec {
 
             describe("unlinkAccountTapped") {
                 beforeEach {
-                    let voidObservable = self.scheduler.createColdObservable([next(50, ())])
-
-                    voidObservable
-                            .bind(to: self.subject.unLinkAccountTapped)
-                            .disposed(by: self.disposeBag)
-                    self.scheduler.start()
+                    self.subject.onViewReady()
+                    self.view.fakeUnlinkAccountButtonPressed.onNext(())
                 }
                 it("displays the alert controller") {
                     expect(self.view.displayAlertActionButtons).notTo(beNil())

--- a/lockbox-iosTests/AccountSettingViewSpec.swift
+++ b/lockbox-iosTests/AccountSettingViewSpec.swift
@@ -17,10 +17,6 @@ class AccountSettingViewSpec: QuickSpec {
         var unlinkAccountStub: TestableObserver<Void>!
         var settingTapStub: TestableObserver<Void>!
 
-        override var unLinkAccountTapped: AnyObserver<Void> {
-            return self.unlinkAccountStub.asObserver()
-        }
-
         override var onSettingsTap: AnyObserver<Void> {
             return self.settingTapStub.asObserver()
         }
@@ -58,12 +54,20 @@ class AccountSettingViewSpec: QuickSpec {
             }
 
             describe("tapping the unlink account button") {
+                var buttonObserver = self.scheduler.createObserver(Void.self)
+                
                 beforeEach {
+                    buttonObserver = self.scheduler.createObserver(Void.self)
+                    
+                    self.subject.unLinkAccountButtonPressed
+                        .subscribe(buttonObserver)
+                        .disposed(by: self.disposeBag)
+                    
                     self.subject.unlinkAccountButton.sendActions(for: .touchUpInside)
                 }
 
-                it("tells the presenter") {
-                    expect(self.presenter.unlinkAccountStub.events.count).to(equal(1))
+                it("tells observers about button taps") {
+                   expect(buttonObserver.events.count).to(be(1))
                 }
             }
 

--- a/lockbox-iosTests/AccountSettingViewSpec.swift
+++ b/lockbox-iosTests/AccountSettingViewSpec.swift
@@ -72,12 +72,21 @@ class AccountSettingViewSpec: QuickSpec {
             }
 
             describe("tapping the back to settings button") {
+                var buttonObserver = self.scheduler.createObserver(Void.self)
+                
                 beforeEach {
-                    (self.subject.navigationItem.leftBarButtonItem!.customView as! UIButton).sendActions(for: .touchUpInside)
+                    buttonObserver = self.scheduler.createObserver(Void.self)
+                    
+                    self.subject.onSettingsButtonPressed!
+                        .subscribe(buttonObserver)
+                        .disposed(by: self.disposeBag)
+                    
+                    let settingsButton = self.subject.navigationItem.leftBarButtonItem?.customView as! UIButton
+                    settingsButton.sendActions(for: .touchUpInside)
                 }
 
-                it("tells the presenter") {
-                    expect(self.presenter.settingTapStub.events.count).to(equal(1))
+                it("tells observers about button taps") {
+                    expect(buttonObserver.events.count).to(be(1))
                 }
             }
 


### PR DESCRIPTION
Connected to #209
Same workflow as #772 and #762, this time for AccountSettingsView 

There's this `interactivePopGestureRecognizer` [(link)](https://github.com/mozilla-lockbox/lockbox-ios/blob/3497d2bbb810568f39efbfd4014a60ec3a35f342/lockbox-ios/View/AccountSettingView.swift#L81) that I didn't want to fuss with, but if you all think that should be included in this refactor as well, I'd happily add that. There's another `interactivePopGestureRecognizer`  in `PreferredBrowserSettingView`, which I'm going to work on next. 

