### PR TITLE
Shutdown db when app is terminating

### DIFF
--- a/Shared/Action/ApplicationLifecycleAction.swift
+++ b/Shared/Action/ApplicationLifecycleAction.swift
@@ -9,6 +9,7 @@ enum LifecycleAction: Action {
     case background
     case startup
     case upgrade(from: Int, to: Int)
+    case shutdown
 }
 
 extension LifecycleAction: Equatable {
@@ -36,6 +37,7 @@ extension LifecycleAction: TelemetryAction {
         case .startup: return .startup
         // TODO add a TelemetryEventMethod for upgrading
         case .upgrade: return .startup
+        case .shutdown: return .shutdown
         }
     }
 

--- a/Shared/Action/TelemetryAction.swift
+++ b/Shared/Action/TelemetryAction.swift
@@ -19,7 +19,7 @@ enum TelemetryEventCategory: String {
 }
 
 enum TelemetryEventMethod: String {
-case tap, startup, foreground, background, settingChanged, show, canceled, login_selected, autofill_locked, autofill_unlocked, refresh, autofill_clear
+case tap, startup, foreground, background, settingChanged, show, canceled, login_selected, autofill_locked, autofill_unlocked, refresh, autofill_clear, shutdown
 }
 
 enum TelemetryEventObject: String {

--- a/Shared/Store/BaseDataStore.swift
+++ b/Shared/Store/BaseDataStore.swift
@@ -171,6 +171,8 @@ class BaseDataStore {
                         if previous <= 2 {
                             self.handleLock()
                         }
+                    case .shutdown:
+                        self.shutdown()
                     default:
                         break
                     }
@@ -231,6 +233,12 @@ class BaseDataStore {
                 }
             })
             .disposed(by: self.disposeBag)
+    }
+
+    public func shutdown() {
+        if !self.profile.isShutdown {
+            self.profile.shutdown()
+        }
     }
 }
 

--- a/lockbox-ios/Common/AppDelegate.swift
+++ b/lockbox-ios/Common/AppDelegate.swift
@@ -65,6 +65,10 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         Dispatcher.shared.dispatch(action: LifecycleAction.foreground)
     }
 
+    func applicationWillTerminate(_ application: UIApplication) {
+        Dispatcher.shared.dispatch(action: LifecycleAction.shutdown)
+    }
+
     private func setupAdjust() {
 #if DEBUG
         let config = ADJConfig(appToken: Constant.app.adjustAppToken, environment: ADJEnvironmentSandbox)


### PR DESCRIPTION
Fixes  #756. 

One of the most frequent crashes has to do with the logins.db being open when the app is being suspended. Specifically the crash includes:
```Termination Description: SPRINGBOARD, org.mozilla.ios.Lockbox was task-suspended with locked system files: | /var/mobile/Containers/Shared/AppGroup/C2B2AD4A-A8C6-4A7F-9876-95AFEB78BA67/profile.lockbox-profile/logins.db | ProcessVisibility: Background | ProcessState: Suspended
```

This was dealt with in FF-iOS a few years back https://bugzilla.mozilla.org/show_bug.cgi?id=1182151

This PR closes the database when the app terminates.