### PR TITLE
propose Pull Request template

### DIFF
--- a/docs/pull_request_template.md
+++ b/docs/pull_request_template.md
@@ -1,0 +1,28 @@
+Fixes #???
+
+_(**Required**: this reference (one or many) will be closed upon merge. Ideally it has the acceptance criteria and designs for features or fixes related to the work in this Pull Request.)_
+
+Connected to #???
+
+_(Optional: other issues or pull requests related to this, but merging should not close it)_
+
+## Testing and Review Notes
+
+_(**Required**: steps to take to confirm this works as expected or other guidance for code, UX, and any other reviewers)_
+
+
+## Screenshots or Videos
+
+_(Optional: to clearly demonstrate the feature or fix to help with testing and reviews)_
+
+
+## To Do
+
+- add “WIP” to the PR title if pushing up but not complete nor ready for review
+- [ ] double check the original issue to confirm it is fully satisfied
+- [ ] add testing notes and screenshots in PR description to help guide reviewers
+- [ ] add unit tests
+  - optional: consider adding integration tests (UI specs)
+- consider running this branch in the simulator and check for warnings
+- [ ] request the "UX" team perform a design review (if/when applicable)
+- [ ] make sure CI builds are passing (e.g.: fix lint and other errors)


### PR DESCRIPTION
Follow up to https://github.com/mozilla-lockbox/lockbox-android/pull/162 to make a PR template

This is meant to help make sure we follow our expected processes and don't forget anything. What do you think @joeyg?

https://help.github.com/articles/about-issue-and-pull-request-templates/#pull-request-templates

## [Link to view the rendered template](https://github.com/mozilla-lockbox/lockbox-ios/blob/add-pr-template/docs/pull_request_template.md) ➡️ 