### PR TITLE
Bump app versions to 1.4.0

### DIFF
--- a/CredentialProvider/Info.plist
+++ b/CredentialProvider/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>XPC!</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.3.3</string>
+	<string>1.4.0</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 	<key>MozDevelopmentTeam</key>

--- a/lockbox-ios/Common/Resources/Info.plist
+++ b/lockbox-ios/Common/Resources/Info.plist
@@ -17,7 +17,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.3.3</string>
+	<string>1.4.0</string>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 	<key>LSApplicationQueriesSchemes</key>


### PR DESCRIPTION
Closes #836

Now that we're requiring a more recent iOS version #822  let's bump the version all the way up to a "major" update to help signal the changes.

## To Do

- add “WIP” to the PR title if pushing up but not complete nor ready for review
- [x] double check the original issue to confirm it is fully satisfied
- [x] make sure CI builds are passing (e.g.: fix lint and other errors)
