### PR TITLE
Capitalize "AutoFIll" to match Apple marketing words

### DIFF
--- a/Shared/Common/Resources/BaseConstants.swift
+++ b/Shared/Common/Resources/BaseConstants.swift
@@ -58,7 +58,7 @@ class Constant {
     }
 
     class string {
-        static let enablingAutofill = NSLocalizedString("autofill.enabling", value: "Updating Autofill...", comment: "Text displayed while autofill credentials are being populated")
+        static let enablingAutofill = NSLocalizedString("autofill.enabling", value: "Updating AutoFill...", comment: "Text displayed while autofill credentials are being populated, caps-case AutoFill is intentional to match Apple's marketing word")
         static let completedEnablingAutofill = NSLocalizedString("autofill.finished_enabling", value: "Finished updating autofill", comment: "Accesibility notification when autofill is done being enabled")
         static let unlockPlaceholder = NSLocalizedString("unlock_placeholder", value: "This will unlock the app.", comment: "Placeholder text when the user's email is unavailable while unlocking Lockbox, shown in Touch ID and passcode prompts")
         static let signInRequired = NSLocalizedString("autofill.signInRequired", value: "Sign in Required", comment: "Title for alert dialog explaining that a user must be signed in to use autofill")


### PR DESCRIPTION
Minor UI nit found when re-enabling AutoFill on iPhone today:

<img width="359" alt="screen shot 2019-01-08 at 11 10 14 am" src="https://user-images.githubusercontent.com/49511/50850034-fec49000-1335-11e9-938a-c62a4fdd4c08.png">

The settings that leads you to see this string is called "AutoFill Passwords" with capital "F". It's also how we refer it to in our app elsewhere. 👨‍🎨 
