### PR TITLE
Add deeper link to FAQ anchor at top of page

### DIFF
--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -2,6 +2,8 @@
 
 ## 1.4.0 (Build 2769)
 
+_Date: 2019-01-08_
+
 We've improved the search experience (and coming soon: added iPad support)! This is a big update and we hope you enjoy it. Here's the full list of changes:
 
 - Updated the search experience to leverage built-in iOS features to help keep it stable and working consistently (which means we now require iOS 11)

--- a/lockbox-ios/Common/Resources/Constants.swift
+++ b/lockbox-ios/Common/Resources/Constants.swift
@@ -10,6 +10,7 @@ extension Constant.app {
     static let appVersion = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String
     static let appVersionCode = 3 // this is the version of the app that will drive updates.
     static let faqURL = "https://lockbox.firefox.com/faq.html"
+    static let faqURLtop = faqURL + "#top"
     static let privacyURL = "https://lockbox.firefox.com/privacy.html"
     static let provideFeedbackURL = "https://qsurvey.mozilla.com/s3/Lockbox-Input?ver=\(appVersion ?? "1.1")"
     static let getSupportURL = "https://discourse.mozilla.org/c/test-pilot/lockbox"

--- a/lockbox-ios/Presenter/SettingListPresenter.swift
+++ b/lockbox-ios/Presenter/SettingListPresenter.swift
@@ -75,7 +75,7 @@ class SettingListPresenter {
             SettingCellConfiguration(
                     text: Constant.string.faq,
                     routeAction: ExternalWebsiteRouteAction(
-                            urlString: Constant.app.faqURL,
+                            urlString: Constant.app.faqURLtop,
                             title: Constant.string.faq,
                             returnRoute: SettingRouteAction.list),
                             accessibilityId: "faqSettingOption")
@@ -207,7 +207,7 @@ extension SettingListPresenter {
     @objc private func learnMoreTapped() {
         self.onSettingCellTapped.onNext(
                 ExternalWebsiteRouteAction(
-                        urlString: Constant.app.faqURL,
+                        urlString: Constant.app.faqURLtop,
                         title: Constant.string.faq,
                         returnRoute: SettingRouteAction.list
                 ))


### PR DESCRIPTION
Related to mozilla-lockbox/mozilla-lockbox.github.io#90