### PR TITLE
531-xcuites-refactor-new-attempt

### DIFF
--- a/LockboxXCUITests/LockBoxScreenGraph.swift
+++ b/LockboxXCUITests/LockBoxScreenGraph.swift
@@ -266,17 +266,4 @@ extension BaseTestCase {
         waitforExistence(settings.cells.staticTexts["Lockbox"])
         settings.cells.staticTexts["Lockbox"].tap()
     }
-
-    func deleteApp(name: String) {
-        app.terminate()
-        let icon = springboard.icons[appName]
-        if icon.exists {
-            let iconFrame = icon.frame
-            let springboardFrame = springboard.frame
-            icon.press(forDuration: 1.3)
-            springboard.coordinate(withNormalizedOffset: CGVector(dx: (iconFrame.minX + 3 * UIScreen.main.scale) / springboardFrame.maxX, dy: (iconFrame.minY + 3 * UIScreen.main.scale) / springboardFrame.maxY)).tap()
-            waitforExistence(springboard.alerts.buttons["Delete"])
-            springboard.alerts.buttons["Delete"].tap()
-        }
-    }
 }

--- a/LockboxXCUITests/LockBoxScreenGraph.swift
+++ b/LockboxXCUITests/LockBoxScreenGraph.swift
@@ -213,6 +213,13 @@ func createScreenGraph(for test: XCTestCase, with app: XCUIApplication) -> MMScr
 }
 
 extension BaseTestCase {
+    func loginToEntryListView() {
+        loginFxAccount()
+        skipAutofillConfiguration()
+        tapOnFinishButton()
+        waitForLockboxEntriesListView()
+    }
+
     func loginFxAccount() {
         userState.fxaPassword = passwordTestAccountLogins
         userState.fxaUsername = emailTestAccountLogins

--- a/LockboxXCUITests/LockboxXCUITests.swift
+++ b/LockboxXCUITests/LockboxXCUITests.swift
@@ -8,7 +8,11 @@ class LockboxXCUITests: BaseTestCase {
 
     override func tearDown() {
         navigator.goto(Screen.AccountSettingsMenu)
-        navigator.performAction(Action.DisconnectFirefoxLockbox)
+        waitforExistence(app.buttons["disconnectFirefoxLockbox.button"], timeout: 3)
+        // Using taps directly because the action is intermittently failing on BB
+        app.buttons["disconnectFirefoxLockbox.button"].tap()
+        waitforExistence(app.buttons["Disconnect"], timeout: 3)
+        app.buttons["Disconnect"].tap()
         waitforExistence(app.buttons["getStarted.button"], timeout: 30)
         navigator.nowAt(Screen.WelcomeScreen)
     }
@@ -76,9 +80,7 @@ class LockboxXCUITests: BaseTestCase {
         tapOnFinishButton()
 
         waitForLockboxEntriesListView()
-        self.unlockApp()
         snapshot("03Settings" + CONTENT_SIZE)
-
         navigator.goto(Screen.AccountSettingsMenu)
         waitforExistence(app.navigationBars["accountSetting.navigationBar"])
         XCTAssertTrue(app.staticTexts["username.Label"].exists)
@@ -269,13 +271,5 @@ class LockboxXCUITests: BaseTestCase {
             waitforExistence(app.tables.cells.staticTexts[firstEntryEmail], timeout: 10)
             navigator.nowAt(Screen.LockboxMainPage)
         }
-    }
-    
-    private func unlockApp() {
-        let springboard = XCUIApplication(bundleIdentifier: "com.apple.springboard")
-        waitforExistence(springboard.secureTextFields["Passcode field"])
-        let passcodeInput = springboard.secureTextFields["Passcode field"]
-        passcodeInput.tap()
-        passcodeInput.typeText("0000\r")
     }
 }

--- a/LockboxXCUITests/LockboxXCUITests.swift
+++ b/LockboxXCUITests/LockboxXCUITests.swift
@@ -7,7 +7,10 @@ import XCTest
 class LockboxXCUITests: BaseTestCase {
 
     override func tearDown() {
-        deleteApp(name: "Lockbox")
+        navigator.goto(Screen.AccountSettingsMenu)
+        navigator.performAction(Action.DisconnectFirefoxLockbox)
+        waitforExistence(app.buttons["getStarted.button"], timeout: 30)
+        navigator.nowAt(Screen.WelcomeScreen)
     }
 
     func testCheckEntryDetailsView() {
@@ -62,6 +65,9 @@ class LockboxXCUITests: BaseTestCase {
         safari.terminate()
 
         app.launch()
+        waitforExistence(app.tables.cells.staticTexts[firstEntryEmail])
+        navigator.nowAt(Screen.LockboxMainPage)
+        navigator.goto(Screen.SettingsMenu)
     }
 
     func testSettingsAccountUI() {
@@ -82,10 +88,6 @@ class LockboxXCUITests: BaseTestCase {
         // Try Cancel disconnecting the account
         navigator.performAction(Action.DisconnectFirefoxLockboxCancel)
         waitforExistence(app.buttons["disconnectFirefoxLockbox.button"])
-
-        // Disconnect the account
-        navigator.performAction(Action.DisconnectFirefoxLockbox)
-        waitforExistence(app.buttons["getStarted.button"])
     }
 
     func testSettings() {
@@ -157,7 +159,7 @@ class LockboxXCUITests: BaseTestCase {
         // There should be two matches
         let twoMatches = app.tables.cells.count
         if  iPad() {
-            XCTAssertEqual(twoMatches, 5)
+            XCTAssertEqual(twoMatches, 111)
         } else {
             XCTAssertEqual(twoMatches, 108)
         }
@@ -165,7 +167,7 @@ class LockboxXCUITests: BaseTestCase {
         searchTextField.typeText("cc")
         let oneMatches = app.tables.cells.count
         if  iPad() {
-            XCTAssertEqual(oneMatches, 4)
+            XCTAssertEqual(oneMatches, 6)
         } else {
             XCTAssertEqual(oneMatches, 3)
         }
@@ -188,6 +190,8 @@ class LockboxXCUITests: BaseTestCase {
         app.buttons["Clear text"].tap()
         let searchFieldValueAfterXButton = searchTextField.value as! String
         XCTAssertEqual(searchFieldValueAfterXButton, "Search your entries")
+        app.buttons["Cancel"].tap()
+        navigator.nowAt(Screen.LockboxMainPage)
     }
 
     func testCheckAutolock() {
@@ -216,6 +220,7 @@ class LockboxXCUITests: BaseTestCase {
         passcodeInput.tap()
         passcodeInput.typeText("0000\r")
         waitforExistence(app.navigationBars["firefoxLockbox.navigationBar"])
+        navigator.nowAt(Screen.LockboxMainPage)
     }
 
     // Verify SetAutofillNow
@@ -260,6 +265,9 @@ class LockboxXCUITests: BaseTestCase {
                 XCTAssertTrue(safari.buttons[safariButtons2].exists)
             }
             safari.terminate()
+            app.launch()
+            waitforExistence(app.tables.cells.staticTexts[firstEntryEmail], timeout: 10)
+            navigator.nowAt(Screen.LockboxMainPage)
         }
     }
     

--- a/LockboxXCUITests/LockboxXCUITests.swift
+++ b/LockboxXCUITests/LockboxXCUITests.swift
@@ -62,7 +62,6 @@ class LockboxXCUITests: BaseTestCase {
         safari.terminate()
 
         app.launch()
-        waitforExistence(app.navigationBars["firefoxLockbox.navigationBar"])
     }
 
     func testSettingsAccountUI() {
@@ -223,7 +222,7 @@ class LockboxXCUITests: BaseTestCase {
     func testSetAutofill() {
         if #available(iOS 12.0, *) {
             let testingURL = "accounts.google.com"
-            let safariButtons1 = "firefoxlockbox@example.com, for this website — Lockbox"
+            let safariButtons1 = "firefoxlockbox@gmail.com, for this website — Lockbox"
             let safariButtons2 = "Use “firefoxlockbox@example.com”"
             loginFxAccount()
             waitforExistence(app.buttons["setupAutofill.button"])
@@ -238,11 +237,6 @@ class LockboxXCUITests: BaseTestCase {
             waitforExistence(settings.cells.staticTexts["Passwords & Accounts"])
             // Configure Passwords & Accounts settings
             configureAutofillSettings()
-            // Wait until the app is updated
-            waitforExistence(settings.alerts["Sign in Required"].buttons["OK"], timeout: 10)
-            settings.alerts["Sign in Required"].buttons["OK"].tap()
-            sleep(5)
-            settings.terminate()
 
             //Open Safari
             safari.launch()
@@ -253,8 +247,7 @@ class LockboxXCUITests: BaseTestCase {
             waitforExistence(safari.otherElements["WebView"].webViews.textFields["Email or phone"], timeout: 15)
             safari.buttons["ReloadButton"].tap()
             waitforExistence(safari.otherElements["WebView"].webViews.textFields["Email or phone"], timeout: 15)
-            safari.otherElements["WebView"].webViews.textFields["Email or phone"].tap()
-            sleep(10)
+
             // Need to confirm what is shown here, different elements have appeared and
             if (safari.buttons["Other passwords"].exists) {
                 safari.buttons["Other passwords"].tap()

--- a/LockboxXCUITests/LockboxXCUITests.swift
+++ b/LockboxXCUITests/LockboxXCUITests.swift
@@ -19,10 +19,7 @@ class LockboxXCUITests: BaseTestCase {
 
     func testCheckEntryDetailsView() {
         snapshot("01Welcome" + CONTENT_SIZE)
-        loginFxAccount()
-        skipAutofillConfiguration()
-        tapOnFinishButton()
-        waitForLockboxEntriesListView()
+        loginToEntryListView()
 
         XCTAssertNotEqual(app.tables.cells.count, 1)
         XCTAssertTrue(app.tables.cells.staticTexts[firstEntryEmail].exists)
@@ -69,17 +66,13 @@ class LockboxXCUITests: BaseTestCase {
         safari.terminate()
 
         app.launch()
-        waitforExistence(app.tables.cells.staticTexts[firstEntryEmail])
+        waitforExistence(app.tables.cells.staticTexts[firstEntryEmail], timeout: 5)
         navigator.nowAt(Screen.LockboxMainPage)
         navigator.goto(Screen.SettingsMenu)
     }
 
     func testSettingsAccountUI() {
-        loginFxAccount()
-        skipAutofillConfiguration()
-        tapOnFinishButton()
-
-        waitForLockboxEntriesListView()
+        loginToEntryListView()
         snapshot("03Settings" + CONTENT_SIZE)
         navigator.goto(Screen.AccountSettingsMenu)
         waitforExistence(app.navigationBars["accountSetting.navigationBar"])
@@ -93,11 +86,7 @@ class LockboxXCUITests: BaseTestCase {
     }
 
     func testSettings() {
-        loginFxAccount()
-        // Check if the account is verified and if not, verify it
-        skipAutofillConfiguration()
-        tapOnFinishButton()
-        waitForLockboxEntriesListView()
+        loginToEntryListView()
 
         // Check OpenSitesIn Menu option
         navigator.goto(Screen.OpenSitesInMenu)
@@ -122,10 +111,7 @@ class LockboxXCUITests: BaseTestCase {
     func testEntriesSortAndSearch() {
         let firstEntryRecentOrder = "bmo.com"
         let firstEntryAphabeticallyOrder = "accounts.firefox.com"
-        loginFxAccount()
-        skipAutofillConfiguration()
-        tapOnFinishButton()
-        waitForLockboxEntriesListView()
+        loginToEntryListView()
 
         // Checking if doing the steps directly works on bb
         waitforExistence(app.buttons["sorting.button"], timeout: 3)
@@ -146,38 +132,37 @@ class LockboxXCUITests: BaseTestCase {
         let buttonLabelInitally = app.buttons["sorting.button"].label
         waitforExistence(app.navigationBars["firefoxLockbox.navigationBar"])
         XCTAssertEqual(buttonLabelInitally, "Select options for sorting your list of entries (currently A-Z)")
-        sleep(2)
 
         // Check that the order has changed again to its initial state
         let firstCellAlphabetically = app.tables.cells.element(boundBy: 0).staticTexts.element(boundBy: 0).label
         XCTAssertEqual(firstCellAlphabetically, firstEntryAphabeticallyOrder)
 
         // Search entries options
-        sleep(5)
         let searchTextField = app.searchFields.firstMatch
-        waitforExistence(searchTextField)
+        waitforExistence(searchTextField, timeout: 3)
         searchTextField.tap()
         searchTextField.typeText("a")
-        // There should be two matches
-        let twoMatches = app.tables.cells.count
+        // There should be the correct number of matches
+        let aMatches = app.tables.cells.count
         if  iPad() {
-            XCTAssertEqual(twoMatches, 111)
+            XCTAssertEqual(aMatches, 111)
         } else {
-            XCTAssertEqual(twoMatches, 108)
+            XCTAssertEqual(aMatches, 108)
         }
-        // There should be one match
+        // There should be less number of matches
         searchTextField.typeText("cc")
-        let oneMatches = app.tables.cells.count
+        let accMatches = app.tables.cells.count
         if  iPad() {
-            XCTAssertEqual(oneMatches, 6)
+            XCTAssertEqual(accMatches, 6)
         } else {
-            XCTAssertEqual(oneMatches, 3)
+            XCTAssertEqual(accMatches, 3)
         }
         // There should not be any matches
         searchTextField.typeText("x")
         waitforExistence(app.cells.staticTexts["noMatchingEntries.label"])
         let noMatches = app.tables.cells.count
         if  iPad() {
+            // There are not matches but the number of rows shown, more on iPad
             XCTAssertEqual(noMatches, 4)
         } else {
             XCTAssertEqual(noMatches, 1)
@@ -197,11 +182,7 @@ class LockboxXCUITests: BaseTestCase {
     }
 
     func testCheckAutolock() {
-        loginFxAccount()
-        // Check if the account is verified and if not, verify it
-        skipAutofillConfiguration()
-        tapOnFinishButton()
-        waitForLockboxEntriesListView()
+        loginToEntryListView()
 
         navigator.goto(Screen.SettingsMenu)
         waitforExistence(app.navigationBars["settings.navigationBar"])

--- a/buddybuild_prebuild.sh
+++ b/buddybuild_prebuild.sh
@@ -2,4 +2,9 @@
 echo "Setting SentryDSN to $SENTRY_DSN"
 /usr/libexec/PlistBuddy -c "Set SentryDSN $SENTRY_DSN" "lockbox-ios/Common/Resources/Info.plist"
 
+if ! [ -x "$(command -v swiftlint)" ] ; then
+echo "swiftlint is not installed, installing"
 brew install swiftlint
+else
+echo "swiftlint already installed"
+fi


### PR DESCRIPTION
Fixes #531 

This PR is based on the work done on previous PR #754.
In addition, the test account has changed. Instead of using the previous one in which the verification was needed we are using the test account that does not need that step. That simplifies the login code and so the tests.

The tests run independently now. The app is removed and re-installed after each test.
There are functions not added to the graph because it does not work with conditionals and so the transition from one screen to another in the onboarding for example would not work depening on the iOS version.



