### PR TITLE
fix backgrounding / foregrounding problems with lock

### DIFF
--- a/Lockbox.xcodeproj/project.pbxproj
+++ b/Lockbox.xcodeproj/project.pbxproj
@@ -45,7 +45,7 @@
 		7AA5429FC403FDC52F2034F0 /* EmptyPlaceholderCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7AA54B659468B5C0D7C3E353 /* EmptyPlaceholderCell.swift */; };
 		7AA54306397C76D229BA199A /* SettingActionSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7AA549951B0D1648DBA0F253 /* SettingActionSpec.swift */; };
 		7AA54363851F23DEF3EB7BDB /* OnboardingConfirmationViewSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7AA54DF673E124AA32EF8EBC /* OnboardingConfirmationViewSpec.swift */; };
-		7AA5439445A0DE14E73A038A /* DataStoreSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7AA5439EEDE4AB222842E7C8 /* DataStoreSpec.swift */; };
+		7AA5439445A0DE14E73A038A /* BaseDataStoreSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7AA5439EEDE4AB222842E7C8 /* BaseDataStoreSpec.swift */; };
 		7AA543A00DEEDF6947B578EC /* AccountStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7AA54146E0C9269A0CE8D53A /* AccountStore.swift */; };
 		7AA543D5D705C1B0B7B78CBD /* AccountAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7AA5492DA3988625D1DAB5BD /* AccountAction.swift */; };
 		7AA543E59B8E38A18A8BE54D /* FxAClient+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7AA542AADC5CB559B59FB3AD /* FxAClient+.swift */; };
@@ -404,7 +404,7 @@
 		7AA5432C1975C7E9053A5CF3 /* TelemetryAction.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TelemetryAction.swift; sourceTree = "<group>"; };
 		7AA543307459610B170AFBD5 /* CopyDisplayStoreSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CopyDisplayStoreSpec.swift; sourceTree = "<group>"; };
 		7AA54375CEA65C18E1EECFB4 /* bootstrap.sh */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.script.sh; path = bootstrap.sh; sourceTree = "<group>"; };
-		7AA5439EEDE4AB222842E7C8 /* DataStoreSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DataStoreSpec.swift; sourceTree = "<group>"; };
+		7AA5439EEDE4AB222842E7C8 /* BaseDataStoreSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BaseDataStoreSpec.swift; sourceTree = "<group>"; };
 		7AA543A8C2F252E8F8C2B1AF /* LifecycleStore.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LifecycleStore.swift; sourceTree = "<group>"; };
 		7AA5445216A3C61522245622 /* UserDefaultStoreSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UserDefaultStoreSpec.swift; sourceTree = "<group>"; };
 		7AA5445B47B7A548F0F0E294 /* Action.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Action.swift; sourceTree = "<group>"; };
@@ -1022,7 +1022,7 @@
 				7AA54FFBEBCACA7A506F5C16 /* DispatcherSpec.swift */,
 				7AA547CE3404CC8123CA455D /* Observable+Spec.swift */,
 				7AA545A7472772984D517CB0 /* ErrorActionSpec.swift */,
-				7AA5439EEDE4AB222842E7C8 /* DataStoreSpec.swift */,
+				7AA5439EEDE4AB222842E7C8 /* BaseDataStoreSpec.swift */,
 				7AA54C53A73B2C31DAB76E08 /* RouteStoreSpec.swift */,
 				7AA5469D908525083C732018 /* RouteActionSpec.swift */,
 				7AA54E826632AFFBA1677E5E /* AccountStoreSpec.swift */,
@@ -1533,7 +1533,7 @@
 				D85CB82121DDCE9F00E19118 /* SplitViewSpec.swift in Sources */,
 				7D44088E20178713001873F6 /* WelcomePresenterSpec.swift in Sources */,
 				7AA54A58F7F289BAD2CE21C3 /* ErrorActionSpec.swift in Sources */,
-				7AA5439445A0DE14E73A038A /* DataStoreSpec.swift in Sources */,
+				7AA5439445A0DE14E73A038A /* BaseDataStoreSpec.swift in Sources */,
 				D84BF22A2160067900990618 /* AutofillInstructionsPresenterSpec.swift in Sources */,
 				D831FEE7205F3D5100EAE19A /* SettingListViewSpec.swift in Sources */,
 				D8D0293220702D9400CC01C6 /* AutoLockSettingsViewSpec.swift in Sources */,

--- a/Lockbox.xcodeproj/project.pbxproj
+++ b/Lockbox.xcodeproj/project.pbxproj
@@ -226,6 +226,8 @@
 		7DB9DEA32140D04700239D31 /* ItemListDisplayAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7AA54E02364E77393B85C6FE /* ItemListDisplayAction.swift */; };
 		7DB9DEA42140D41E00239D31 /* UIFont+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 224A6C7C212C8C2B008C7A3F /* UIFont+.swift */; };
 		7DB9DEA52140D56E00239D31 /* ItemListDisplayStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7AA54766081BC269C5C33884 /* ItemListDisplayStore.swift */; };
+		7DBDBBC822726E1E00A4EF14 /* DataStoreSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7DBDBBC722726E1E00A4EF14 /* DataStoreSupport.swift */; };
+		7DBDBBC922726E1E00A4EF14 /* DataStoreSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7DBDBBC722726E1E00A4EF14 /* DataStoreSupport.swift */; };
 		7DC3899C20B600820057929D /* ItemDetail.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 7DC3899E20B600820057929D /* ItemDetail.storyboard */; };
 		7DC75D79206AD01C007CDDBB /* AccountSetting.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 7DC75D7B206AD01C007CDDBB /* AccountSetting.storyboard */; };
 		7DDEAA622124B24E00A7D521 /* Dispatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7AA54CDEA56C47263160AD0E /* Dispatcher.swift */; };
@@ -547,6 +549,7 @@
 		7DA4C6902028FB0900B61DD8 /* UIColor+.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIColor+.swift"; sourceTree = "<group>"; };
 		7DB9DE952140C5F400239D31 /* BaseItemListPresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseItemListPresenter.swift; sourceTree = "<group>"; };
 		7DB9DEA02140CC0300239D31 /* ItemListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ItemListView.swift; sourceTree = "<group>"; };
+		7DBDBBC722726E1E00A4EF14 /* DataStoreSupport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataStoreSupport.swift; sourceTree = "<group>"; };
 		7DC3899D20B600820057929D /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/ItemDetail.storyboard; sourceTree = "<group>"; };
 		7DC389A020B600830057929D /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/ItemDetail.strings; sourceTree = "<group>"; };
 		7DC75D7A206AD01C007CDDBB /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/AccountSetting.storyboard; sourceTree = "<group>"; };
@@ -758,6 +761,7 @@
 				D85CB82221DED0E100E19118 /* ViewFactory.swift */,
 				7D116239225FAF11009097C7 /* AutoLockSupport.swift */,
 				7D897EAE2261074700257946 /* NetworkProtocols.swift */,
+				7DBDBBC722726E1E00A4EF14 /* DataStoreSupport.swift */,
 			);
 			path = Helpers;
 			sourceTree = "<group>";
@@ -1684,6 +1688,7 @@
 				D819A4BF21BB2622004EE6F3 /* AppInfo.swift in Sources */,
 				7AA541981624DF66E83FFB72 /* ApplicationLifecycleAction.swift in Sources */,
 				7AA54E336336462A6DEB79EE /* LifecycleStore.swift in Sources */,
+				7DBDBBC822726E1E00A4EF14 /* DataStoreSupport.swift in Sources */,
 				7AA5429FC403FDC52F2034F0 /* EmptyPlaceholderCell.swift in Sources */,
 				7AA54C565CB9C3C8651D97C8 /* ExternalWebsiteNavigationController.swift in Sources */,
 				7D07FE94225E32C40000B030 /* NetworkStore.swift in Sources */,
@@ -1701,6 +1706,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				7DBDBBC922726E1E00A4EF14 /* DataStoreSupport.swift in Sources */,
 				D819A4BD21BAFA6F004EE6F3 /* File.swift in Sources */,
 				7D09B2522125F9DB00794CA2 /* CredentialProviderPresenter.swift in Sources */,
 				7DE5896E2125D20C005CFF47 /* CredentialAccountStore.swift in Sources */,

--- a/Shared/Action/ApplicationLifecycleAction.swift
+++ b/Shared/Action/ApplicationLifecycleAction.swift
@@ -21,6 +21,8 @@ extension LifecycleAction: Equatable {
             return true
         case (.startup, .startup):
             return true
+        case (.shutdown, .shutdown):
+            return true
         case let (.upgrade(l1, l2), .upgrade(r1, r2)):
             return l1 == r1 && l2 == r2
         default:

--- a/Shared/Common/Helpers/DataStoreSupport.swift
+++ b/Shared/Common/Helpers/DataStoreSupport.swift
@@ -17,6 +17,7 @@ public protocol LoginsStorageProtocol {
     func list() throws -> [LoginRecord]
 }
 
+// We decorate the LoginsStorage with the LoginsStorageProtocol so that it's easy to mock and inject for unit testing.
 extension LoginsStorage: LoginsStorageProtocol { }
 
 class DataStoreSupport {

--- a/Shared/Common/Helpers/DataStoreSupport.swift
+++ b/Shared/Common/Helpers/DataStoreSupport.swift
@@ -1,0 +1,28 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+import Foundation
+import MozillaAppServices
+
+public protocol LoginsStorageProtocol {
+    func close()
+    func isLocked() -> Bool
+    func ensureUnlocked(withEncryptionKey key: String) throws
+    func ensureLocked()
+    func sync(unlockInfo: SyncUnlockInfo) throws
+    func wipeLocal() throws
+    func get(id: String) throws -> LoginRecord?
+    func touch(id: String) throws
+    func list() throws -> [LoginRecord]
+}
+
+extension LoginsStorage: LoginsStorageProtocol { }
+
+class DataStoreSupport {
+    static let shared: DataStoreSupport = DataStoreSupport()
+
+    open func createLoginsStorage(databasePath: String) -> LoginsStorageProtocol {
+        return LoginsStorage(databasePath: databasePath)
+    }
+}

--- a/Shared/Store/LifecycleStore.swift
+++ b/Shared/Store/LifecycleStore.swift
@@ -13,7 +13,7 @@ class LifecycleStore {
     private let dispatcher: Dispatcher
     private let _lifecycleFilter = PublishSubject<LifecycleAction>()
 
-    public var lifecycleFilter: Observable<LifecycleAction> {
+    public var lifecycleEvents: Observable<LifecycleAction> {
         return _lifecycleFilter.asObservable()
     }
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,6 +1,3 @@
 ignore:
     - "LockboxXCUITests/*"
-    - "Shared/Store/BaseDataStore.swift"
-    - "lockbox-ios/Store/DataStore.swift"
-    - "CredentialProvider/Store/Datastore.swift"
     - "lockbox-iosTests/*"

--- a/lockbox-ios/Presenter/RootPresenter.swift
+++ b/lockbox-ios/Presenter/RootPresenter.swift
@@ -136,7 +136,7 @@ class RootPresenter {
             })
             .disposed(by: self.disposeBag)
 
-        self.lifecycleStore.lifecycleFilter
+        self.lifecycleStore.lifecycleEvents
             .subscribe(onNext: { lifecycleAction in
                 switch lifecycleAction {
                 case .foreground:

--- a/lockbox-ios/Presenter/WelcomePresenter.swift
+++ b/lockbox-ios/Presenter/WelcomePresenter.swift
@@ -112,7 +112,7 @@ extension WelcomePresenter {
     }
 
     private func setupBiometricLaunchers() {
-        let lifecycleObservable = self.lifecycleStore.lifecycleFilter
+        let lifecycleObservable = self.lifecycleStore.lifecycleEvents
                 .filter { action -> Bool in
             return action == LifecycleAction.foreground
         }

--- a/lockbox-iosTests/ApplicationLifecycleActionSpec.swift
+++ b/lockbox-iosTests/ApplicationLifecycleActionSpec.swift
@@ -43,6 +43,27 @@ class ApplicationLifecycleActionSpec: QuickSpec {
                     expect(LifecycleAction.startup.extras).to(beNil())
                 }
             }
+
+            describe("equality") {
+                it("basic lifecycles") {
+                    expect(LifecycleAction.foreground).to(equal(LifecycleAction.foreground))
+                    expect(LifecycleAction.background).to(equal(LifecycleAction.background))
+                    expect(LifecycleAction.startup).to(equal(LifecycleAction.startup))
+                    expect(LifecycleAction.shutdown).to(equal(LifecycleAction.shutdown))
+                    expect(LifecycleAction.foreground).notTo(equal(LifecycleAction.background))
+                    expect(LifecycleAction.background).notTo(equal(LifecycleAction.startup))
+                    expect(LifecycleAction.startup).notTo(equal(LifecycleAction.shutdown))
+                    expect(LifecycleAction.shutdown).notTo(equal(LifecycleAction.foreground))
+                }
+
+                it("upgrade") {
+                    expect(LifecycleAction.upgrade(from: 1, to: 1)).to(equal(LifecycleAction.upgrade(from: 1, to: 1)))
+                    expect(LifecycleAction.upgrade(from: 1, to: 2)).to(equal(LifecycleAction.upgrade(from: 1, to: 2)))
+                    expect(LifecycleAction.upgrade(from: 1, to: 2)).notTo(equal(LifecycleAction.upgrade(from: 2, to: 2)))
+                    expect(LifecycleAction.upgrade(from: 1, to: 2)).notTo(equal(LifecycleAction.upgrade(from: 2, to: 3)))
+                    expect(LifecycleAction.upgrade(from: 2, to: 2)).notTo(equal(LifecycleAction.upgrade(from: 2, to: 3)))
+                }
+            }
         }
     }
 }

--- a/lockbox-iosTests/DataStoreSpec.swift
+++ b/lockbox-iosTests/DataStoreSpec.swift
@@ -9,15 +9,104 @@ import RxTest
 import RxSwift
 import RxBlocking
 import SwiftKeychainWrapper
+import MozillaAppServices
 
 @testable import Lockbox
 
 class DataStoreSpec: QuickSpec {
-    class FakeDispatcher: Dispatcher {
-        let fakeRegistration = PublishSubject<Action>()
+    class FakeLoginsStorage: LoginsStorageProtocol {
+        var closeCalled = false
+        var lockedStub = false
+        var ensureUnlockedArgument: String?
+        var ensureLockedCalled = false
+        var syncArgument: SyncUnlockInfo?
+        var wipeLocalCalled = false
+        var getIdArgument: String?
+        var getStub: LoginRecord?
+        var touchIdArgument: String?
+        var listStub: [LoginRecord] = []
 
-        override var register: Observable<Action> {
-            return self.fakeRegistration.asObservable()
+        func close() {
+            closeCalled = true
+        }
+
+        func isLocked() -> Bool {
+            return lockedStub
+        }
+
+        func ensureUnlocked(withEncryptionKey key: String) throws {
+            self.ensureUnlockedArgument = key
+        }
+
+        func ensureLocked() {
+            self.ensureLockedCalled = true
+        }
+
+        func sync(unlockInfo: SyncUnlockInfo) throws {
+            self.syncArgument = unlockInfo
+        }
+
+        func wipeLocal() throws {
+            self.wipeLocalCalled = true
+        }
+
+        func get(id: String) throws -> LoginRecord? {
+            self.getIdArgument = id
+            return self.getStub
+        }
+
+        func touch(id: String) throws {
+            self.touchIdArgument = id
+        }
+
+        func list() throws -> [LoginRecord] {
+            return listStub
+        }
+
+        func clearInvocations() {
+            self.closeCalled = false
+            self.ensureUnlockedArgument = nil
+            self.ensureLockedCalled = false
+            self.syncArgument = nil
+            self.wipeLocalCalled = false
+            self.getIdArgument = nil
+            self.touchIdArgument = nil
+        }
+    }
+
+    class FakeDataStoreSupport: DataStoreSupport {
+        var createArgument: String?
+        let loginsStorage: LoginsStorageProtocol
+
+        init(loginsStorageStub: LoginsStorageProtocol) {
+            self.loginsStorage = loginsStorageStub
+        }
+
+        override func createLoginsStorage(databasePath: String) -> LoginsStorageProtocol {
+            return self.loginsStorage
+        }
+    }
+
+    class FakeAutoLockSupport: AutoLockSupport {
+        var lockRequiredStub: Bool = false
+        var storeNextTimeCalled = false
+        var backdateCalled = false
+        var forwardDateCalled = false
+
+        override var lockCurrentlyRequired: Bool {
+            return self.lockRequiredStub
+        }
+
+        override func storeNextAutolockTime() {
+            self.storeNextTimeCalled = true
+        }
+
+        override func forwardDateNextLockTime() {
+            self.forwardDateCalled = true
+        }
+
+        override func backDateNextLockTime() {
+            self.backdateCalled = true
         }
     }
 
@@ -35,25 +124,114 @@ class DataStoreSpec: QuickSpec {
             return retrieveResult[key]
         }
 
-        init() { super.init(serviceName: "blah") }
+        init() {
+            super.init(serviceName: "blah")
+        }
     }
 
-    private var scheduler: TestScheduler = TestScheduler(initialClock: 1)
-    private var disposeBag = DisposeBag()
+    class FakeLifecycleStore: LifecycleStore {
+        var fakeCycle = PublishSubject<LifecycleAction>()
 
-    private var dispatcher: FakeDispatcher!
+        override var lifecycleEvents: Observable<LifecycleAction> {
+            return self.fakeCycle.asObservable()
+        }
+    }
+
+    class FakeDataStoreImpl: BaseDataStore {
+        override init(dispatcher: Dispatcher = Dispatcher.shared,
+             keychainWrapper: KeychainWrapper = KeychainWrapper.standard,
+             autoLockSupport: AutoLockSupport = AutoLockSupport.shared,
+             dataStoreSupport: DataStoreSupport = DataStoreSupport.shared,
+             accountStore: BaseAccountStore = AccountStore.shared,
+             networkStore: NetworkStore = NetworkStore.shared,
+             lifecycleStore: LifecycleStore = LifecycleStore.shared) {
+            super.init(
+                    dispatcher: dispatcher,
+                    keychainWrapper: keychainWrapper,
+                    autoLockSupport: autoLockSupport,
+                    dataStoreSupport: dataStoreSupport,
+                    accountStore: accountStore,
+                    networkStore: networkStore,
+                    lifecycleStore: lifecycleStore
+            )
+        }
+
+        override func initialized() {}
+    }
+
+    private var loginsStorage: FakeLoginsStorage!
+    private var logins: [LoginRecord] = [
+        LoginRecord(fromJSONDict: [:]),
+        LoginRecord(fromJSONDict: [:]),
+        LoginRecord(fromJSONDict: [:]),
+        LoginRecord(fromJSONDict: [:]),
+        LoginRecord(fromJSONDict: [:])
+    ]
+
+    private let scheduler = TestScheduler.init(initialClock: 0)
+    private let disposeBag = DisposeBag()
+    private var listObserver: TestableObserver<[LoginRecord]>!
+    private var stateObserver: TestableObserver<LoginStoreState>!
+    private var syncObserver: TestableObserver<SyncState>!
+
+    private var dispatcher: Dispatcher!
     private var keychainWrapper: FakeKeychainWrapper!
-    var subject: DataStore!
+    private var autoLockSupport: FakeAutoLockSupport!
+    private var dataStoreSupport: FakeDataStoreSupport!
+    private var lifecycleStore: FakeLifecycleStore!
+    var subject: BaseDataStore!
 
     override func spec() {
         describe("DataStore") {
             beforeEach {
-                self.dispatcher = FakeDispatcher()
+                self.loginsStorage = FakeLoginsStorage()
+                self.dispatcher = Dispatcher()
                 self.keychainWrapper = FakeKeychainWrapper()
-                self.subject = DataStore(
+                self.autoLockSupport = FakeAutoLockSupport()
+                self.dataStoreSupport = FakeDataStoreSupport(loginsStorageStub: self.loginsStorage)
+                self.lifecycleStore = FakeLifecycleStore()
+                self.subject = FakeDataStoreImpl(
                         dispatcher: self.dispatcher,
-                        keychainWrapper: self.keychainWrapper
+                        keychainWrapper: self.keychainWrapper,
+                        autoLockSupport: self.autoLockSupport,
+                        dataStoreSupport: self.dataStoreSupport,
+                        lifecycleStore: self.lifecycleStore
                 )
+
+                self.loginsStorage.listStub = self.logins
+
+                self.stateObserver = self.scheduler.createObserver(LoginStoreState.self)
+                self.listObserver = self.scheduler.createObserver([LoginRecord].self)
+                self.syncObserver = self.scheduler.createObserver(SyncState.self)
+
+                self.subject.list
+                    .subscribe(self.listObserver)
+                    .disposed(by: self.disposeBag)
+
+                self.subject.syncState
+                    .subscribe(self.syncObserver)
+                    .disposed(by: self.disposeBag)
+
+                self.subject.storageState
+                    .subscribe(self.stateObserver)
+                    .disposed(by: self.disposeBag)
+            }
+
+            it("takes initialization steps") {
+                expect(self.dataStoreSupport.createArgument).notTo(beNil())
+            }
+
+            describe("reset / unprepared state") {
+                beforeEach {
+                    self.dispatcher.dispatch(action: DataStoreAction.reset)
+                }
+
+                it("pushes unprepared and wipes the loginsstorage") {
+                    expect(self.loginsStorage.ensureUnlockedArgument).notTo(beNil())
+                    expect(self.loginsStorage.wipeLocalCalled).to(beTrue())
+                    expect(self.listObserver.events.last!.value.element!).to(beEmpty())
+                    expect(self.stateObserver.events.last!.value.element!).to(equal(LoginStoreState.Unprepared))
+                }
             }
         }
     }

--- a/lockbox-iosTests/LifecycleStoreSpec.swift
+++ b/lockbox-iosTests/LifecycleStoreSpec.swift
@@ -37,7 +37,7 @@ class LifecycleStoreSpec: QuickSpec {
                 beforeEach {
                     lifecycleObserver = self.scheduler.createObserver(LifecycleAction.self)
 
-                    self.subject.lifecycleFilter
+                    self.subject.lifecycleEvents
                             .bind(to: lifecycleObserver)
                             .disposed(by: self.disposeBag)
                 }

--- a/lockbox-iosTests/RootPresenterSpec.swift
+++ b/lockbox-iosTests/RootPresenterSpec.swift
@@ -231,7 +231,7 @@ class RootPresenterSpec: QuickSpec {
     class FakeLifecycleStore: LifecycleStore {
         var filterStub = PublishSubject<LifecycleAction>()
 
-        override var lifecycleFilter: Observable<LifecycleAction> {
+        override var lifecycleEvents: Observable<LifecycleAction> {
             return self.filterStub.asObservable()
         }
     }

--- a/lockbox-iosTests/WelcomePresenterSpec.swift
+++ b/lockbox-iosTests/WelcomePresenterSpec.swift
@@ -119,7 +119,7 @@ class WelcomePresenterSpec: QuickSpec {
     class FakeLifecycleStore: LifecycleStore {
         var fakeCycle = PublishSubject<LifecycleAction>()
 
-        override var lifecycleFilter: Observable<LifecycleAction> {
+        override var lifecycleEvents: Observable<LifecycleAction> {
             return self.fakeCycle.asObservable()
         }
     }


### PR DESCRIPTION
Fixes #898
Fixes #926 
Fixes #924 

Connected to #895

## Testing and Review Notes
This also fixes a bug introduced at #916 in which using the Lock Now button and then foregrounding before the autolock time would unlock the app.

For codereviewers: I got a head start on #895 in this issue so that all of the locking behavior can be more explicitly tested.

## To Do

- [x] add “WIP” to the PR title if pushing up but not complete nor ready for review
- [x] double check the original issue to confirm it is fully satisfied
- [x] add testing notes and screenshots in PR description to help guide reviewers
- [x] add unit tests
- [x] make sure CI builds are passing (e.g.: fix lint and other errors)
