### PR TITLE
Set launch constraits so no gray bar shown

### DIFF
--- a/lockbox-ios/Storyboard/LaunchScreen.storyboard
+++ b/lockbox-ios/Storyboard/LaunchScreen.storyboard
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14460.31" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="01J-lp-oVM">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14490.70" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="01J-lp-oVM">
     <device id="ipad12_9" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14460.20"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14490.49"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -47,7 +47,7 @@
                         </subviews>
                         <color key="backgroundColor" red="0.93725490196078431" green="0.95294117647058818" blue="0.96078431372549022" alpha="1" colorSpace="calibratedRGB"/>
                         <constraints>
-                            <constraint firstItem="Bcu-3y-fUS" firstAttribute="trailing" secondItem="lq4-q7-MSJ" secondAttribute="trailing" id="2ap-S2-4Lu"/>
+                            <constraint firstAttribute="trailing" secondItem="lq4-q7-MSJ" secondAttribute="trailing" id="2ap-S2-4Lu"/>
                             <constraint firstItem="qO8-pl-kvW" firstAttribute="trailing" secondItem="Bcu-3y-fUS" secondAttribute="trailing" id="3if-Mn-FCa"/>
                             <constraint firstItem="JiV-R4-O2D" firstAttribute="centerX" secondItem="Bcu-3y-fUS" secondAttribute="centerX" id="5n5-A7-7ul"/>
                             <constraint firstItem="lq4-q7-MSJ" firstAttribute="leading" secondItem="Bcu-3y-fUS" secondAttribute="leading" id="CCz-UJ-oLT"/>
@@ -58,7 +58,7 @@
                             <constraint firstItem="lq4-q7-MSJ" firstAttribute="top" secondItem="wCL-jn-auR" secondAttribute="centerY" id="SIH-JU-9pp"/>
                             <constraint firstItem="qO8-pl-kvW" firstAttribute="top" secondItem="Bcu-3y-fUS" secondAttribute="top" constant="160" id="U6h-yK-jRB"/>
                             <constraint firstItem="qO8-pl-kvW" firstAttribute="leading" secondItem="Bcu-3y-fUS" secondAttribute="leading" id="f20-RF-WtH"/>
-                            <constraint firstItem="Bcu-3y-fUS" firstAttribute="bottom" secondItem="lq4-q7-MSJ" secondAttribute="bottom" id="fht-KP-QmM"/>
+                            <constraint firstAttribute="bottom" secondItem="lq4-q7-MSJ" secondAttribute="bottom" id="fht-KP-QmM"/>
                             <constraint firstItem="JiV-R4-O2D" firstAttribute="top" secondItem="qO8-pl-kvW" secondAttribute="bottom" constant="73" id="oE0-I3-KFh"/>
                             <constraint firstItem="wCL-jn-auR" firstAttribute="centerX" secondItem="Ze5-6b-2t3" secondAttribute="centerX" id="w4k-WE-ibc"/>
                         </constraints>


### PR DESCRIPTION
Fixes #935 

## Testing and Review Notes

- force quit the app
- open it and see the launch screen
- confirm the blue of the ocean extends to edge of bottom of screen (doesn't stop short and leave a grey bar)

I confirmed in the interface builder preview across all devices.

I also tested on a physical iPhone XS (which previously experienced this problem).

## Screenshots or Videos

_(Optional: to clearly demonstrate the feature or fix to help with testing and reviews)_

Before (interface builder):

<img width="305" alt="image" src="https://user-images.githubusercontent.com/49511/57035562-96b0f700-6c0f-11e9-9cdd-eb0f54835f1d.png">


After iPhone XS (interface builder):

<img width="301" alt="image" src="https://user-images.githubusercontent.com/49511/57035639-c829c280-6c0f-11e9-9e4f-7fab1511172a.png">




## To Do

- [x] double check the original issue to confirm it is fully satisfied
- [x] add testing notes and screenshots in PR description to help guide reviewers
- [x] request the "UX" team perform a design review (if/when applicable)
- [x] make sure CI builds are passing (e.g.: fix lint and other errors)
